### PR TITLE
Switch to 2019/20

### DIFF
--- a/data/parkrun-special-events/2019-20/parsed/all.json
+++ b/data/parkrun-special-events/2019-20/parsed/all.json
@@ -1,0 +1,2736 @@
+{
+  "Boxing Day": {
+    "date": "2019-12-26",
+    "events": {
+      "parkrun Kedzierzyn-Kozle": {
+        "country_code": "pl",
+        "country_domain": "www.parkrun.pl",
+        "longname": "parkrun Kedzierzyn-Kozle",
+        "shortname": "kedzierzyn-kozle",
+        "time": "09:00"
+      },
+      "parkrun Warszawa-Ursynow": {
+        "country_code": "pl",
+        "country_domain": "www.parkrun.pl",
+        "longname": "parkrun Warszawa-Ursynow",
+        "shortname": "warszawa-ursynow",
+        "time": "09:00"
+      }
+    },
+    "index": 2
+  },
+  "Chinese New Year": {
+    "date": "2020-01-20",
+    "events": {},
+    "index": 3
+  },
+  "Christmas Day": {
+    "date": "2019-12-25",
+    "events": {
+      "Albert parkrun, Middlesbrough": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Albert parkrun, Middlesbrough",
+        "shortname": "albert",
+        "time": "09:00"
+      },
+      "Anderson parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Anderson parkrun",
+        "shortname": "anderson",
+        "time": "08:00"
+      },
+      "Aylesbury parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Aylesbury parkrun",
+        "shortname": "aylesbury",
+        "time": "09:00"
+      },
+      "Ballincollig parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Ballincollig parkrun",
+        "shortname": "ballincollig",
+        "time": "09:30"
+      },
+      "Balyang Sanctuary parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Balyang Sanctuary parkrun",
+        "shortname": "balyangsanctuary",
+        "time": "08:00"
+      },
+      "Barking parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Barking parkrun",
+        "shortname": "barking",
+        "time": "09:00"
+      },
+      "Barry Island parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Barry Island parkrun",
+        "shortname": "barryisland",
+        "time": "09:00"
+      },
+      "Basildon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Basildon parkrun",
+        "shortname": "basildon",
+        "time": "09:00"
+      },
+      "Basingstoke parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Basingstoke parkrun",
+        "shortname": "basingstoke",
+        "time": "09:00"
+      },
+      "Bedford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bedford parkrun",
+        "shortname": "bedford",
+        "time": "09:00"
+      },
+      "Beeston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Beeston parkrun",
+        "shortname": "beeston",
+        "time": "09:00"
+      },
+      "Bethlem Royal Hospital parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bethlem Royal Hospital parkrun",
+        "shortname": "bethlemroyalhospital",
+        "time": "09:00"
+      },
+      "Bexley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bexley parkrun",
+        "shortname": "bexley",
+        "time": "09:00"
+      },
+      "Bibra Lake parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Bibra Lake parkrun",
+        "shortname": "bibralake",
+        "time": "08:00"
+      },
+      "Bicester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bicester parkrun",
+        "shortname": "bicester",
+        "time": "09:00"
+      },
+      "Billericay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Billericay parkrun",
+        "shortname": "billericay",
+        "time": "09:00"
+      },
+      "Blandford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Blandford parkrun",
+        "shortname": "blandford",
+        "time": "09:00"
+      },
+      "Blyth Links parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Blyth Links parkrun",
+        "shortname": "blythlinks",
+        "time": "09:00"
+      },
+      "Boston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Boston parkrun",
+        "shortname": "boston",
+        "time": "09:00"
+      },
+      "Braunstone parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Braunstone parkrun",
+        "shortname": "braunstone",
+        "time": "09:00"
+      },
+      "Bronberrik parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Bronberrik parkrun",
+        "shortname": "bronberrik",
+        "time": "08:00"
+      },
+      "Buckingham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Buckingham parkrun",
+        "shortname": "buckingham",
+        "time": "09:00"
+      },
+      "Cairns parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Cairns parkrun",
+        "shortname": "cairns",
+        "time": "07:00"
+      },
+      "Catford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Catford parkrun",
+        "shortname": "catford",
+        "time": "09:00"
+      },
+      "Chichester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chichester parkrun",
+        "shortname": "chichester",
+        "time": "09:00"
+      },
+      "Chippenham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chippenham parkrun",
+        "shortname": "chippenham",
+        "time": "09:00"
+      },
+      "Clair parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Clair parkrun",
+        "shortname": "clair",
+        "time": "09:00"
+      },
+      "Cleethorpes parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Cleethorpes parkrun",
+        "shortname": "cleethorpes",
+        "time": "09:00"
+      },
+      "Cliffe Castle parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Cliffe Castle parkrun",
+        "shortname": "cliffecastle",
+        "time": "09:00"
+      },
+      "Clonmel parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Clonmel parkrun",
+        "shortname": "clonmel",
+        "time": "09:30"
+      },
+      "Colchester junior parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Colchester junior parkrun",
+        "shortname": "colchester-juniors",
+        "time": "09:00"
+      },
+      "Conkers parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Conkers parkrun",
+        "shortname": "conkers",
+        "time": "09:00"
+      },
+      "Darlington South Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Darlington South Park parkrun",
+        "shortname": "darlingtonsouthpark",
+        "time": "09:00"
+      },
+      "Daventry parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Daventry parkrun",
+        "shortname": "daventry",
+        "time": "09:00"
+      },
+      "Delamere parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Delamere parkrun",
+        "shortname": "delamere",
+        "time": "09:00"
+      },
+      "Delta parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Delta parkrun",
+        "shortname": "delta",
+        "time": "08:00"
+      },
+      "Doncaster parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Doncaster parkrun",
+        "shortname": "doncaster",
+        "time": "09:00"
+      },
+      "Dubbo parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Dubbo parkrun",
+        "shortname": "dubbo",
+        "time": "08:00"
+      },
+      "Eastbourne parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Eastbourne parkrun",
+        "shortname": "eastbourne",
+        "time": "09:00"
+      },
+      "Elgin parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Elgin parkrun",
+        "shortname": "elgin",
+        "time": "09:30"
+      },
+      "Euroa parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Euroa parkrun",
+        "shortname": "euroa",
+        "time": "08:00"
+      },
+      "Exeter Riverside parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Exeter Riverside parkrun",
+        "shortname": "exeterriverside",
+        "time": "09:00"
+      },
+      "Fareham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Fareham parkrun",
+        "shortname": "fareham",
+        "time": "09:00"
+      },
+      "Fingal Bay parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Fingal Bay parkrun",
+        "shortname": "fingalbay",
+        "time": "08:00"
+      },
+      "Flaxmere parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Flaxmere parkrun",
+        "shortname": "flaxmere",
+        "time": "08:00"
+      },
+      "Forest Rec parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Forest Rec parkrun",
+        "shortname": "forestrec",
+        "time": "09:00"
+      },
+      "Forest of Dean parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Forest of Dean parkrun",
+        "shortname": "forest-of-dean",
+        "time": "09:00"
+      },
+      "Frimley Lodge parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Frimley Lodge parkrun",
+        "shortname": "frimleylodge",
+        "time": "09:00"
+      },
+      "Gisborne parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Gisborne parkrun",
+        "shortname": "gisborne",
+        "time": "08:00"
+      },
+      "Goulburn parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Goulburn parkrun",
+        "shortname": "goulburn",
+        "time": "08:00"
+      },
+      "Great Lines parkrun, Medway": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Great Lines parkrun, Medway",
+        "shortname": "greatlines",
+        "time": "09:00"
+      },
+      "Great Notley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Great Notley parkrun",
+        "shortname": "greatnotley",
+        "time": "09:00"
+      },
+      "Greenbank parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Greenbank parkrun",
+        "shortname": "greenbank",
+        "time": "07:00"
+      },
+      "Greenwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Greenwich parkrun",
+        "shortname": "greenwich",
+        "time": "09:00"
+      },
+      "Greytown Woodside Trail parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Greytown Woodside Trail parkrun",
+        "shortname": "greytownwoodsidetrail",
+        "time": "08:00"
+      },
+      "Grovelands parkrun, Enfield": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Grovelands parkrun, Enfield",
+        "shortname": "grovelands",
+        "time": "09:00"
+      },
+      "Guildford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Guildford parkrun",
+        "shortname": "guildford",
+        "time": "09:00"
+      },
+      "Hadleigh parkrun, Essex": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hadleigh parkrun, Essex",
+        "shortname": "hadleigh",
+        "time": "09:00"
+      },
+      "Harlow parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Harlow parkrun",
+        "shortname": "harlow",
+        "time": "09:00"
+      },
+      "Hartlepool parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hartlepool parkrun",
+        "shortname": "hartlepool",
+        "time": "09:00"
+      },
+      "Heartlands parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Heartlands parkrun",
+        "shortname": "heartlands",
+        "time": "09:00"
+      },
+      "Henstridge Airfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Henstridge Airfield parkrun",
+        "shortname": "henstridgeairfield",
+        "time": "09:00"
+      },
+      "Herrington Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Herrington Country parkrun",
+        "shortname": "herringtoncountry",
+        "time": "09:00"
+      },
+      "Highbury Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Highbury Fields parkrun",
+        "shortname": "highburyfields",
+        "time": "09:00"
+      },
+      "Highfields parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Highfields parkrun",
+        "shortname": "highfields",
+        "time": "07:00"
+      },
+      "Hobsonville Point parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Hobsonville Point parkrun",
+        "shortname": "hobsonvillepoint",
+        "time": "08:00"
+      },
+      "Homewood parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Homewood parkrun",
+        "shortname": "homewood",
+        "time": "09:00"
+      },
+      "Huddersfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Huddersfield parkrun",
+        "shortname": "huddersfield",
+        "time": "09:00"
+      },
+      "Hull parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hull parkrun",
+        "shortname": "hull",
+        "time": "09:00"
+      },
+      "Huntingdon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Huntingdon parkrun",
+        "shortname": "huntingdon",
+        "time": "09:00"
+      },
+      "Inverloch parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Inverloch parkrun",
+        "shortname": "inverloch",
+        "time": "08:00"
+      },
+      "Jersey parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Jersey parkrun",
+        "shortname": "jersey",
+        "time": "09:00"
+      },
+      "Kimberley parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Kimberley parkrun",
+        "shortname": "kimberley",
+        "time": "07:00"
+      },
+      "Koster parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Koster parkrun",
+        "shortname": "koster",
+        "time": "07:00"
+      },
+      "Lee-on-the-Solent parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Lee-on-the-Solent parkrun",
+        "shortname": "leeonthesolent",
+        "time": "09:00"
+      },
+      "Lincoln parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Lincoln parkrun",
+        "shortname": "lincoln",
+        "time": "09:00"
+      },
+      "Linwood parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Linwood parkrun",
+        "shortname": "linwood",
+        "time": "09:30"
+      },
+      "Livingston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Livingston parkrun",
+        "shortname": "livingston",
+        "time": "09:30"
+      },
+      "Malahide parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Malahide parkrun",
+        "shortname": "malahide",
+        "time": "09:30"
+      },
+      "Maldon Prom parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Maldon Prom parkrun",
+        "shortname": "maldonprom",
+        "time": "09:00"
+      },
+      "Malling parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Malling parkrun",
+        "shortname": "malling",
+        "time": "09:00"
+      },
+      "Melton Mowbray parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Melton Mowbray parkrun",
+        "shortname": "meltonmowbray",
+        "time": "09:00"
+      },
+      "Millfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Millfield parkrun",
+        "shortname": "millfield",
+        "time": "09:00"
+      },
+      "Milton Keynes parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Milton Keynes parkrun",
+        "shortname": "miltonkeynes",
+        "time": "09:00"
+      },
+      "Mogol parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Mogol parkrun",
+        "shortname": "mogol",
+        "time": "07:00"
+      },
+      "Montrose Foreshore parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Montrose Foreshore parkrun",
+        "shortname": "montroseforeshore",
+        "time": "09:00"
+      },
+      "Netley Abbey parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Netley Abbey parkrun",
+        "shortname": "netleyabbey",
+        "time": "09:00"
+      },
+      "Newark parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Newark parkrun",
+        "shortname": "newark",
+        "time": "09:00"
+      },
+      "Newport Lakes parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Newport Lakes parkrun",
+        "shortname": "newportlakes",
+        "time": "08:00"
+      },
+      "North Shore parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "North Shore parkrun",
+        "shortname": "northshore",
+        "time": "07:00"
+      },
+      "Northala Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Northala Fields parkrun",
+        "shortname": "northalafields",
+        "time": "09:00"
+      },
+      "Northallerton parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Northallerton parkrun",
+        "shortname": "northallerton",
+        "time": "09:00"
+      },
+      "Northwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Northwich parkrun",
+        "shortname": "northwich",
+        "time": "09:00"
+      },
+      "Norwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Norwich parkrun",
+        "shortname": "norwich",
+        "time": "09:00"
+      },
+      "Oak Hill parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Oak Hill parkrun",
+        "shortname": "oak-hill",
+        "time": "09:00"
+      },
+      "Old Deer Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Old Deer Park parkrun",
+        "shortname": "olddeerpark",
+        "time": "09:00"
+      },
+      "Panshanger parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Panshanger parkrun",
+        "shortname": "panshanger",
+        "time": "09:00"
+      },
+      "Pegasus parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Pegasus parkrun",
+        "shortname": "pegasus",
+        "time": "08:00"
+      },
+      "Poole parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Poole parkrun",
+        "shortname": "poole",
+        "time": "09:00"
+      },
+      "Poolsbrook parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Poolsbrook parkrun",
+        "shortname": "poolsbrook",
+        "time": "09:00"
+      },
+      "Portrush junior parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Portrush junior parkrun",
+        "shortname": "portrush-juniors",
+        "time": "09:30"
+      },
+      "Preston Park parkrun, Brighton": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Preston Park parkrun, Brighton",
+        "shortname": "prestonpark",
+        "time": "09:00"
+      },
+      "Preston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Preston parkrun",
+        "shortname": "preston",
+        "time": "09:00"
+      },
+      "Prospect parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Prospect parkrun",
+        "shortname": "prospect",
+        "time": "09:00"
+      },
+      "Richmond parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Richmond parkrun",
+        "shortname": "richmond",
+        "time": "09:00"
+      },
+      "Roundhay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Roundhay parkrun",
+        "shortname": "roundhay",
+        "time": "09:00"
+      },
+      "Royal Tunbridge Wells parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Royal Tunbridge Wells parkrun",
+        "shortname": "royaltunbridgewells",
+        "time": "09:00"
+      },
+      "Sandgate parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Sandgate parkrun",
+        "shortname": "sandgate",
+        "time": "07:00"
+      },
+      "Seacliff Esplanade parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Seacliff Esplanade parkrun",
+        "shortname": "seacliffesplanade",
+        "time": "08:00"
+      },
+      "Selby parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Selby parkrun",
+        "shortname": "selby",
+        "time": "09:00"
+      },
+      "Severn Valley Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Severn Valley Country parkrun",
+        "shortname": "severnvalleycountry",
+        "time": "09:00"
+      },
+      "Shrewsbury parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Shrewsbury parkrun",
+        "shortname": "shrewsbury",
+        "time": "09:00"
+      },
+      "South Manchester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "South Manchester parkrun",
+        "shortname": "southmanchester",
+        "time": "09:00"
+      },
+      "South Woodham Ferrers parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "South Woodham Ferrers parkrun",
+        "shortname": "southwoodhamferrers",
+        "time": "09:00"
+      },
+      "Southsea parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southsea parkrun",
+        "shortname": "southsea",
+        "time": "09:00"
+      },
+      "Southwark parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southwark parkrun",
+        "shortname": "southwark",
+        "time": "09:00"
+      },
+      "St Albans parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "St Albans parkrun",
+        "shortname": "stalbans",
+        "time": "09:00"
+      },
+      "St Helens parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "St Helens parkrun",
+        "shortname": "sthelens",
+        "time": "09:00"
+      },
+      "Stonehaven parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Stonehaven parkrun",
+        "shortname": "stonehaven",
+        "time": "09:30"
+      },
+      "Street parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Street parkrun",
+        "shortname": "street",
+        "time": "09:00"
+      },
+      "Studley parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Studley parkrun",
+        "shortname": "studley",
+        "time": "08:00"
+      },
+      "The Ponds parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "The Ponds parkrun",
+        "shortname": "theponds",
+        "time": "08:00"
+      },
+      "The Wammy parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "The Wammy parkrun",
+        "shortname": "thewammy",
+        "time": "09:00"
+      },
+      "Tralee parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Tralee parkrun",
+        "shortname": "tralee",
+        "time": "09:30"
+      },
+      "Tring parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Tring parkrun",
+        "shortname": "tring",
+        "time": "09:00"
+      },
+      "Troon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Troon parkrun",
+        "shortname": "troon",
+        "time": "09:30"
+      },
+      "Wallace parkrun, Lisburn": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Wallace parkrun, Lisburn",
+        "shortname": "wallace",
+        "time": "09:30"
+      },
+      "Walmer and Deal Seafront parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Walmer and Deal Seafront parkrun",
+        "shortname": "walmeranddealseafront",
+        "time": "09:00"
+      },
+      "Walsall Arboretum parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Walsall Arboretum parkrun",
+        "shortname": "walsall",
+        "time": "09:00"
+      },
+      "Whangarei parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Whangarei parkrun",
+        "shortname": "whangarei",
+        "time": "08:00"
+      },
+      "Whiteley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Whiteley parkrun",
+        "shortname": "whiteley",
+        "time": "09:00"
+      },
+      "Whitstable parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Whitstable parkrun",
+        "shortname": "whitstable",
+        "time": "09:00"
+      },
+      "Widnes parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Widnes parkrun",
+        "shortname": "widnes",
+        "time": "09:00"
+      },
+      "Wilmslow parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Wilmslow parkrun",
+        "shortname": "wilmslow",
+        "time": "09:00"
+      },
+      "Witton parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Witton parkrun",
+        "shortname": "witton",
+        "time": "09:00"
+      },
+      "Woodhouse Moor parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Woodhouse Moor parkrun",
+        "shortname": "woodhousemoor",
+        "time": "09:00"
+      },
+      "Woodley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Woodley parkrun",
+        "shortname": "woodley",
+        "time": "09:00"
+      },
+      "Worcester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Worcester parkrun",
+        "shortname": "worcester",
+        "time": "09:00"
+      },
+      "Wyndham Vale parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Wyndham Vale parkrun",
+        "shortname": "wyndhamvale",
+        "time": "08:00"
+      },
+      "York parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "York parkrun",
+        "shortname": "york",
+        "time": "09:00"
+      }
+    },
+    "index": 2
+  },
+  "Christmas Eve": {
+    "date": "2019-12-24",
+    "events": {},
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {
+      "Albert parkrun, Middlesbrough": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Albert parkrun, Middlesbrough",
+        "shortname": "albert",
+        "time": "10:30"
+      },
+      "Anderson parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Anderson parkrun",
+        "shortname": "anderson",
+        "time": "08:00"
+      },
+      "Ballincollig parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Ballincollig parkrun",
+        "shortname": "ballincollig",
+        "time": "09:30"
+      },
+      "Balyang Sanctuary parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Balyang Sanctuary parkrun",
+        "shortname": "balyangsanctuary",
+        "time": "07:30"
+      },
+      "Barry Island parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Barry Island parkrun",
+        "shortname": "barryisland",
+        "time": "09:00"
+      },
+      "Basingstoke parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Basingstoke parkrun",
+        "shortname": "basingstoke",
+        "time": "09:00"
+      },
+      "Bedford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bedford parkrun",
+        "shortname": "bedford",
+        "time": "09:00"
+      },
+      "Bellville parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Bellville parkrun",
+        "shortname": "bellville",
+        "time": "08:00"
+      },
+      "Belton House parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Belton House parkrun",
+        "shortname": "beltonhouse",
+        "time": "09:00"
+      },
+      "Bexley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bexley parkrun",
+        "shortname": "bexley",
+        "time": "10:30"
+      },
+      "Bibra Lake parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Bibra Lake parkrun",
+        "shortname": "bibralake",
+        "time": "09:30"
+      },
+      "Billericay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Billericay parkrun",
+        "shortname": "billericay",
+        "time": "09:00"
+      },
+      "Black Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Black Park parkrun",
+        "shortname": "blackpark",
+        "time": "09:00"
+      },
+      "Blackpool parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Blackpool parkrun",
+        "shortname": "blackpool",
+        "time": "10:00"
+      },
+      "Blyth Links parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Blyth Links parkrun",
+        "shortname": "blythlinks",
+        "time": "10:30"
+      },
+      "Bowral parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Bowral parkrun",
+        "shortname": "bowral",
+        "time": "09:30"
+      },
+      "Bracknell parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bracknell parkrun",
+        "shortname": "bracknell",
+        "time": "08:30"
+      },
+      "Braunstone parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Braunstone parkrun",
+        "shortname": "braunstone",
+        "time": "10:30"
+      },
+      "Brickfields parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Brickfields parkrun",
+        "shortname": "brickfields",
+        "time": "11:00"
+      },
+      "Brighton & Hove parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Brighton & Hove parkrun",
+        "shortname": "brighton",
+        "time": "10:30"
+      },
+      "Bryanston parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Bryanston parkrun",
+        "shortname": "bryanston",
+        "time": "07:30"
+      },
+      "Cairns parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Cairns parkrun",
+        "shortname": "cairns",
+        "time": "07:00"
+      },
+      "Calleya parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Calleya parkrun",
+        "shortname": "calleya",
+        "time": "07:30"
+      },
+      "Campbelltown parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Campbelltown parkrun",
+        "shortname": "campbelltown",
+        "time": "07:00"
+      },
+      "Carisbrooke parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Carisbrooke parkrun",
+        "shortname": "carisbrooke",
+        "time": "09:30"
+      },
+      "Catford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Catford parkrun",
+        "shortname": "catford",
+        "time": "10:30"
+      },
+      "Chester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chester parkrun",
+        "shortname": "chester",
+        "time": "09:00"
+      },
+      "Chichester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chichester parkrun",
+        "shortname": "chichester",
+        "time": "09:00"
+      },
+      "Chippenham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chippenham parkrun",
+        "shortname": "chippenham",
+        "time": "10:30"
+      },
+      "Clacton Seafront parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Clacton Seafront parkrun",
+        "shortname": "clactonseafront",
+        "time": "10:30"
+      },
+      "Clermont Waterfront parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Clermont Waterfront parkrun",
+        "shortname": "clermontwaterfront",
+        "time": "09:00"
+      },
+      "Cliffe Castle parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Cliffe Castle parkrun",
+        "shortname": "cliffecastle",
+        "time": "10:30"
+      },
+      "Clonmel parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Clonmel parkrun",
+        "shortname": "clonmel",
+        "time": "11:00"
+      },
+      "College Park parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "College Park parkrun",
+        "shortname": "collegepark",
+        "time": "10:30"
+      },
+      "Colwick parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Colwick parkrun",
+        "shortname": "colwick",
+        "time": "10:30"
+      },
+      "Conkers parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Conkers parkrun",
+        "shortname": "conkers",
+        "time": "09:00"
+      },
+      "Conyngham Hall parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Conyngham Hall parkrun",
+        "shortname": "conynghamhall",
+        "time": "10:30"
+      },
+      "Cotsford Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Cotsford Fields parkrun",
+        "shortname": "cotsfordfields",
+        "time": "09:00"
+      },
+      "Darlington South Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Darlington South Park parkrun",
+        "shortname": "darlingtonsouthpark",
+        "time": "10:30"
+      },
+      "Daventry parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Daventry parkrun",
+        "shortname": "daventry",
+        "time": "10:30"
+      },
+      "Delamere parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Delamere parkrun",
+        "shortname": "delamere",
+        "time": "09:00"
+      },
+      "Delta parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Delta parkrun",
+        "shortname": "delta",
+        "time": "09:30"
+      },
+      "Dubbo parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Dubbo parkrun",
+        "shortname": "dubbo",
+        "time": "08:00"
+      },
+      "Durham NC parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Durham NC parkrun",
+        "shortname": "durhamnc",
+        "time": "09:30"
+      },
+      "Eastbourne parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Eastbourne parkrun",
+        "shortname": "eastbourne",
+        "time": "09:00"
+      },
+      "Eden Project parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Eden Project parkrun",
+        "shortname": "edenproject",
+        "time": "09:00"
+      },
+      "Elgin parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Elgin parkrun",
+        "shortname": "elgin",
+        "time": "11:00"
+      },
+      "Ellenbrook Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Ellenbrook Fields parkrun",
+        "shortname": "ellenbrookfields",
+        "time": "10:30"
+      },
+      "Exmouth parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Exmouth parkrun",
+        "shortname": "exmouth",
+        "time": "08:30"
+      },
+      "Fareham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Fareham parkrun",
+        "shortname": "fareham",
+        "time": "09:00"
+      },
+      "Felixstowe parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Felixstowe parkrun",
+        "shortname": "felixstowe",
+        "time": "10:30"
+      },
+      "Fingal Bay parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Fingal Bay parkrun",
+        "shortname": "fingalbay",
+        "time": "08:00"
+      },
+      "Flaxmere parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Flaxmere parkrun",
+        "shortname": "flaxmere",
+        "time": "09:30"
+      },
+      "Fletcher's Cove parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Fletcher's Cove parkrun",
+        "shortname": "fletcherscove",
+        "time": "10:30"
+      },
+      "Forest Lake parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Forest Lake parkrun",
+        "shortname": "forestlake",
+        "time": "08:30"
+      },
+      "Forest of Dean parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Forest of Dean parkrun",
+        "shortname": "forest-of-dean",
+        "time": "10:00"
+      },
+      "Frickley Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Frickley Country parkrun",
+        "shortname": "frickleycountry",
+        "time": "10:30"
+      },
+      "Frimley Lodge parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Frimley Lodge parkrun",
+        "shortname": "frimleylodge",
+        "time": "10:00"
+      },
+      "Gedling parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Gedling parkrun",
+        "shortname": "gedling",
+        "time": "09:00"
+      },
+      "Gisborne parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Gisborne parkrun",
+        "shortname": "gisborne",
+        "time": "09:00"
+      },
+      "Gladstone parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Gladstone parkrun",
+        "shortname": "gladstone",
+        "time": "10:30"
+      },
+      "Glen River parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Glen River parkrun",
+        "shortname": "glenriver",
+        "time": "11:00"
+      },
+      "Gloucester City parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Gloucester City parkrun",
+        "shortname": "gloucestercity",
+        "time": "10:30"
+      },
+      "Great Notley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Great Notley parkrun",
+        "shortname": "greatnotley",
+        "time": "09:00"
+      },
+      "Greenwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Greenwich parkrun",
+        "shortname": "greenwich",
+        "time": "09:00"
+      },
+      "Grovelands parkrun, Enfield": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Grovelands parkrun, Enfield",
+        "shortname": "grovelands",
+        "time": "09:00"
+      },
+      "Guildford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Guildford parkrun",
+        "shortname": "guildford",
+        "time": "09:00"
+      },
+      "Harkerville parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Harkerville parkrun",
+        "shortname": "harkerville",
+        "time": "09:00"
+      },
+      "Harrow Lodge parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Harrow Lodge parkrun",
+        "shortname": "harrowlodge",
+        "time": "10:30"
+      },
+      "Hartlepool parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hartlepool parkrun",
+        "shortname": "hartlepool",
+        "time": "10:30"
+      },
+      "Hastings parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hastings parkrun",
+        "shortname": "hastings",
+        "time": "09:00"
+      },
+      "Heartlands parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Heartlands parkrun",
+        "shortname": "heartlands",
+        "time": "08:30"
+      },
+      "Henstridge Airfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Henstridge Airfield parkrun",
+        "shortname": "henstridgeairfield",
+        "time": "09:00"
+      },
+      "Herrington Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Herrington Country parkrun",
+        "shortname": "herringtoncountry",
+        "time": "10:30"
+      },
+      "Hervey Bay parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Hervey Bay parkrun",
+        "shortname": "herveybay",
+        "time": "06:30"
+      },
+      "Highbury Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Highbury Fields parkrun",
+        "shortname": "highburyfields",
+        "time": "09:00"
+      },
+      "Highfields parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Highfields parkrun",
+        "shortname": "highfields",
+        "time": "08:30"
+      },
+      "Himmel parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Himmel parkrun",
+        "shortname": "himmel",
+        "time": "09:00"
+      },
+      "Hobart parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Hobart parkrun",
+        "shortname": "hobart",
+        "time": "08:30"
+      },
+      "Hobsonville Point parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Hobsonville Point parkrun",
+        "shortname": "hobsonvillepoint",
+        "time": "09:30"
+      },
+      "Hockley Woods parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hockley Woods parkrun",
+        "shortname": "hockleywoods",
+        "time": "10:30"
+      },
+      "Hove Promenade parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hove Promenade parkrun",
+        "shortname": "hovepromenade",
+        "time": "09:00"
+      },
+      "Huddersfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Huddersfield parkrun",
+        "shortname": "huddersfield",
+        "time": "10:30"
+      },
+      "Huntingdon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Huntingdon parkrun",
+        "shortname": "huntingdon",
+        "time": "09:00"
+      },
+      "Hyndburn parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hyndburn parkrun",
+        "shortname": "hyndburn",
+        "time": "10:30"
+      },
+      "Jamaica Pond parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Jamaica Pond parkrun",
+        "shortname": "jamaicapond",
+        "time": "10:00"
+      },
+      "Jersey parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Jersey parkrun",
+        "shortname": "jersey",
+        "time": "10:00"
+      },
+      "Kensington parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Kensington parkrun",
+        "shortname": "kensington",
+        "time": "08:30"
+      },
+      "Kettering parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Kettering parkrun",
+        "shortname": "kettering",
+        "time": "10:30"
+      },
+      "Killerton parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Killerton parkrun",
+        "shortname": "killerton",
+        "time": "08:30"
+      },
+      "Kimberley parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Kimberley parkrun",
+        "shortname": "kimberley",
+        "time": "07:00"
+      },
+      "King's Lynn parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "King's Lynn parkrun",
+        "shortname": "kingslynn",
+        "time": "09:00"
+      },
+      "Knowsley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Knowsley parkrun",
+        "shortname": "knowsley",
+        "time": "10:30"
+      },
+      "Koster parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Koster parkrun",
+        "shortname": "koster",
+        "time": "08:30"
+      },
+      "Lee-on-the-Solent parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Lee-on-the-Solent parkrun",
+        "shortname": "leeonthesolent",
+        "time": "10:30"
+      },
+      "Lillie parkrun, Ann Arbor": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Lillie parkrun, Ann Arbor",
+        "shortname": "lillie",
+        "time": "10:30"
+      },
+      "Listowel parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Listowel parkrun",
+        "shortname": "listowel",
+        "time": "09:00"
+      },
+      "Livingston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Livingston parkrun",
+        "shortname": "livingston",
+        "time": "11:00"
+      },
+      "Livonia parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Livonia parkrun",
+        "shortname": "livonia",
+        "time": "08:30"
+      },
+      "Loch Leven parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Loch Leven parkrun",
+        "shortname": "lochleven",
+        "time": "11:00"
+      },
+      "Lytham Hall parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Lytham Hall parkrun",
+        "shortname": "lythamhall",
+        "time": "08:30"
+      },
+      "Maldon Prom parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Maldon Prom parkrun",
+        "shortname": "maldonprom",
+        "time": "09:00"
+      },
+      "Medina I.O.W. parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Medina I.O.W. parkrun",
+        "shortname": "medina",
+        "time": "10:00"
+      },
+      "Melton Mowbray parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Melton Mowbray parkrun",
+        "shortname": "meltonmowbray",
+        "time": "09:00"
+      },
+      "Mernda parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Mernda parkrun",
+        "shortname": "mernda",
+        "time": "08:00"
+      },
+      "Mogol parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Mogol parkrun",
+        "shortname": "mogol",
+        "time": "07:00"
+      },
+      "Montrose Foreshore parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Montrose Foreshore parkrun",
+        "shortname": "montroseforeshore",
+        "time": "10:30"
+      },
+      "Mullum Mullum parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Mullum Mullum parkrun",
+        "shortname": "mullummullum",
+        "time": "09:30"
+      },
+      "Netley Abbey parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Netley Abbey parkrun",
+        "shortname": "netleyabbey",
+        "time": "09:00"
+      },
+      "Newark parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Newark parkrun",
+        "shortname": "newark",
+        "time": "10:30"
+      },
+      "Newborough Forest parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Newborough Forest parkrun",
+        "shortname": "newboroughforest",
+        "time": "09:00"
+      },
+      "North Shore parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "North Shore parkrun",
+        "shortname": "northshore",
+        "time": "08:00"
+      },
+      "Northwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Northwich parkrun",
+        "shortname": "northwich",
+        "time": "10:30"
+      },
+      "Nostell parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Nostell parkrun",
+        "shortname": "nostell",
+        "time": "08:30"
+      },
+      "Oak Grove parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Oak Grove parkrun",
+        "shortname": "oakgrove",
+        "time": "10:00"
+      },
+      "Oak Hill parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Oak Hill parkrun",
+        "shortname": "oak-hill",
+        "time": "10:30"
+      },
+      "Old Deer Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Old Deer Park parkrun",
+        "shortname": "olddeerpark",
+        "time": "09:00"
+      },
+      "Osterley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Osterley parkrun",
+        "shortname": "osterley",
+        "time": "10:30"
+      },
+      "Pakenham parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Pakenham parkrun",
+        "shortname": "pakenham",
+        "time": "08:00"
+      },
+      "Panshanger parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Panshanger parkrun",
+        "shortname": "panshanger",
+        "time": "09:00"
+      },
+      "Pegwell Bay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Pegwell Bay parkrun",
+        "shortname": "pegwellbay",
+        "time": "10:30"
+      },
+      "Penallta parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Penallta parkrun",
+        "shortname": "penallta",
+        "time": "10:30"
+      },
+      "Pennington Flash parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Pennington Flash parkrun",
+        "shortname": "penningtonflash",
+        "time": "10:30"
+      },
+      "Perrigo parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Perrigo parkrun",
+        "shortname": "perrigo",
+        "time": "08:30"
+      },
+      "Poolsbrook parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Poolsbrook parkrun",
+        "shortname": "poolsbrook",
+        "time": "10:30"
+      },
+      "Portrush parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Portrush parkrun",
+        "shortname": "portrush",
+        "time": "09:30"
+      },
+      "Prospect parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Prospect parkrun",
+        "shortname": "prospect",
+        "time": "10:30"
+      },
+      "Queen Elizabeth parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Queen Elizabeth parkrun",
+        "shortname": "queenelizabeth",
+        "time": "10:30"
+      },
+      "Ramsbottom junior parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Ramsbottom junior parkrun",
+        "shortname": "ramsbottom-juniors",
+        "time": "10:30"
+      },
+      "Rec Plex North parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Rec Plex North parkrun",
+        "shortname": "recplexnorth",
+        "time": "07:30"
+      },
+      "Redcar parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Redcar parkrun",
+        "shortname": "redcar",
+        "time": "10:30"
+      },
+      "Redland Bay parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Redland Bay parkrun",
+        "shortname": "redlandbay",
+        "time": "07:00"
+      },
+      "Renton parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Renton parkrun",
+        "shortname": "renton",
+        "time": "10:30"
+      },
+      "Richmond parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Richmond parkrun",
+        "shortname": "richmond",
+        "time": "09:00"
+      },
+      "Rocks Riverside parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Rocks Riverside parkrun",
+        "shortname": "rocksriverside",
+        "time": "08:30"
+      },
+      "Rothwell parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Rothwell parkrun",
+        "shortname": "rothwell",
+        "time": "10:30"
+      },
+      "Royal Canal parkrun, Kilcock": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Royal Canal parkrun, Kilcock",
+        "shortname": "royalcanalkilcock",
+        "time": "11:00"
+      },
+      "Rushmere parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Rushmere parkrun",
+        "shortname": "rushmere",
+        "time": "09:00"
+      },
+      "Sandgate parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Sandgate parkrun",
+        "shortname": "sandgate",
+        "time": "07:00"
+      },
+      "Seacliff Esplanade parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Seacliff Esplanade parkrun",
+        "shortname": "seacliffesplanade",
+        "time": "09:30"
+      },
+      "Selby parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Selby parkrun",
+        "shortname": "selby",
+        "time": "10:30"
+      },
+      "Severn Valley Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Severn Valley Country parkrun",
+        "shortname": "severnvalleycountry",
+        "time": "10:30"
+      },
+      "Shepton Mallet parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Shepton Mallet parkrun",
+        "shortname": "sheptonmallet",
+        "time": "08:30"
+      },
+      "Shipley Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Shipley Country parkrun",
+        "shortname": "shipleycountry",
+        "time": "09:00"
+      },
+      "Shrewsbury parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Shrewsbury parkrun",
+        "shortname": "shrewsbury",
+        "time": "08:30"
+      },
+      "South Boulder Creek parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "South Boulder Creek parkrun",
+        "shortname": "southbouldercreek",
+        "time": "10:30"
+      },
+      "South Manchester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "South Manchester parkrun",
+        "shortname": "southmanchester",
+        "time": "09:00"
+      },
+      "South Woodham Ferrers parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "South Woodham Ferrers parkrun",
+        "shortname": "southwoodhamferrers",
+        "time": "10:30"
+      },
+      "Southsea parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southsea parkrun",
+        "shortname": "southsea",
+        "time": "09:00"
+      },
+      "Southwark parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southwark parkrun",
+        "shortname": "southwark",
+        "time": "10:30"
+      },
+      "Southwick Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southwick Country parkrun",
+        "shortname": "southwickcountrypark",
+        "time": "09:00"
+      },
+      "Squerryes Winery parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Squerryes Winery parkrun",
+        "shortname": "squerryeswinery",
+        "time": "10:30"
+      },
+      "St Albans parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "St Albans parkrun",
+        "shortname": "stalbans",
+        "time": "10:30"
+      },
+      "St Helens parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "St Helens parkrun",
+        "shortname": "sthelens",
+        "time": "08:30"
+      },
+      "St Lucia parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "St Lucia parkrun",
+        "shortname": "stlucia",
+        "time": "07:00"
+      },
+      "Sterkfontein parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Sterkfontein parkrun",
+        "shortname": "sterkfontein",
+        "time": "07:30"
+      },
+      "Stonehaven parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Stonehaven parkrun",
+        "shortname": "stonehaven",
+        "time": "11:00"
+      },
+      "Street parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Street parkrun",
+        "shortname": "street",
+        "time": "10:30"
+      },
+      "Stretford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Stretford parkrun",
+        "shortname": "stretford",
+        "time": "10:30"
+      },
+      "Swansea Bay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Swansea Bay parkrun",
+        "shortname": "swanseabay",
+        "time": "10:30"
+      },
+      "Swindon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Swindon parkrun",
+        "shortname": "swindon",
+        "time": "10:30"
+      },
+      "Telford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Telford parkrun",
+        "shortname": "telford",
+        "time": "10:30"
+      },
+      "The Ponds parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "The Ponds parkrun",
+        "shortname": "theponds",
+        "time": "09:00"
+      },
+      "The Wammy parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "The Wammy parkrun",
+        "shortname": "thewammy",
+        "time": "10:30"
+      },
+      "Tralee parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Tralee parkrun",
+        "shortname": "tralee",
+        "time": "11:00"
+      },
+      "Tring parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Tring parkrun",
+        "shortname": "tring",
+        "time": "09:00"
+      },
+      "Troon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Troon parkrun",
+        "shortname": "troon",
+        "time": "11:00"
+      },
+      "Upton House parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Upton House parkrun",
+        "shortname": "uptonhouse",
+        "time": "08:30"
+      },
+      "Vogrie parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Vogrie parkrun",
+        "shortname": "vogrie",
+        "time": "11:00"
+      },
+      "Walmer and Deal Seafront parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Walmer and Deal Seafront parkrun",
+        "shortname": "walmeranddealseafront",
+        "time": "08:30"
+      },
+      "Watermeadows parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Watermeadows parkrun",
+        "shortname": "watermeadows",
+        "time": "09:00"
+      },
+      "Wepre parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Wepre parkrun",
+        "shortname": "wepre",
+        "time": "10:30"
+      },
+      "Westmill parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Westmill parkrun",
+        "shortname": "westmill",
+        "time": "10:30"
+      },
+      "Whiteley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Whiteley parkrun",
+        "shortname": "whiteley",
+        "time": "09:00"
+      },
+      "Whitstable parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Whitstable parkrun",
+        "shortname": "whitstable",
+        "time": "09:00"
+      },
+      "Widnes parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Widnes parkrun",
+        "shortname": "widnes",
+        "time": "10:30"
+      },
+      "Wilmslow parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Wilmslow parkrun",
+        "shortname": "wilmslow",
+        "time": "10:30"
+      },
+      "Witney parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Witney parkrun",
+        "shortname": "witney",
+        "time": "09:00"
+      },
+      "Witton parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Witton parkrun",
+        "shortname": "witton",
+        "time": "08:30"
+      },
+      "Woodbridge Riverside parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Woodbridge Riverside parkrun",
+        "shortname": "woodbridgeriverside",
+        "time": "09:00"
+      },
+      "Woodhouse Moor parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Woodhouse Moor parkrun",
+        "shortname": "woodhousemoor",
+        "time": "09:00"
+      },
+      "Woodley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Woodley parkrun",
+        "shortname": "woodley",
+        "time": "10:30"
+      },
+      "Wyndham Vale parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Wyndham Vale parkrun",
+        "shortname": "wyndhamvale",
+        "time": "09:30"
+      },
+      "Yeovil Montacute parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Yeovil Montacute parkrun",
+        "shortname": "yeovilmontacute",
+        "time": "10:30"
+      },
+      "York parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "York parkrun",
+        "shortname": "york",
+        "time": "09:00"
+      },
+      "parkrun Kedzierzyn-Kozle": {
+        "country_code": "pl",
+        "country_domain": "www.parkrun.pl",
+        "longname": "parkrun Kedzierzyn-Kozle",
+        "shortname": "kedzierzyn-kozle",
+        "time": "10:00"
+      }
+    },
+    "index": 2
+  },
+  "Orthodox Christmas": {
+    "date": "2020-01-07",
+    "events": {
+      "parkrun Butovo": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Butovo",
+        "shortname": "butovo",
+        "time": "09:00"
+      },
+      "parkrun Cheboksary naberezhnaya": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Cheboksary naberezhnaya",
+        "shortname": "cheboksarynaberezhnaya",
+        "time": "10:00"
+      },
+      "parkrun Chelyabinsk": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Chelyabinsk",
+        "shortname": "chelyabinsk",
+        "time": "09:00"
+      },
+      "parkrun Dolgoprudny": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Dolgoprudny",
+        "shortname": "dolgoprudny",
+        "time": "10:00"
+      },
+      "parkrun Ekaterinburg Zelenaya Roscha": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Ekaterinburg Zelenaya Roscha",
+        "shortname": "ekaterinburgzelenayaroscha",
+        "time": "10:00"
+      },
+      "parkrun Elagin Ostrov": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Elagin Ostrov",
+        "shortname": "elaginostrov",
+        "time": "10:00"
+      },
+      "parkrun Khimki": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Khimki",
+        "shortname": "khimki",
+        "time": "10:00"
+      },
+      "parkrun Kimry": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Kimry",
+        "shortname": "kimry",
+        "time": "09:00"
+      },
+      "parkrun Kolomenskoe": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Kolomenskoe",
+        "shortname": "kolomenskoe",
+        "time": "10:00"
+      },
+      "parkrun Kolpino": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Kolpino",
+        "shortname": "kolpino",
+        "time": "10:00"
+      },
+      "parkrun Krylatskoe": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Krylatskoe",
+        "shortname": "krylatskoe",
+        "time": "09:00"
+      },
+      "parkrun Kuzminki": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Kuzminki",
+        "shortname": "kuzminki",
+        "time": "09:00"
+      },
+      "parkrun Mega Park Kudrovo": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Mega Park Kudrovo",
+        "shortname": "megaparkkudrovo",
+        "time": "09:30"
+      },
+      "parkrun Meshchersky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Meshchersky",
+        "shortname": "meshchersky",
+        "time": "09:00"
+      },
+      "parkrun Natashinsky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Natashinsky",
+        "shortname": "natashinsky",
+        "time": "10:00"
+      },
+      "parkrun Olimpiyskaya Derevnya": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Olimpiyskaya Derevnya",
+        "shortname": "olimpiyskayaderevnya",
+        "time": "09:00"
+      },
+      "parkrun Pavlovsky Posad": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Pavlovsky Posad",
+        "shortname": "pavlovskyposad",
+        "time": "09:00"
+      },
+      "parkrun Perm Balatovo": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Perm Balatovo",
+        "shortname": "permbalatovo",
+        "time": "10:00"
+      },
+      "parkrun Petergof Aleksandriysky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Petergof Aleksandriysky",
+        "shortname": "petergofaleksandriysky",
+        "time": "10:00"
+      },
+      "parkrun Pushkin": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Pushkin",
+        "shortname": "pushkin",
+        "time": "10:00"
+      },
+      "parkrun Samara Park Gagarina": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Samara Park Gagarina",
+        "shortname": "samaraparkgagarina",
+        "time": "10:00"
+      },
+      "parkrun Severnoe Tushino": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Severnoe Tushino",
+        "shortname": "severnoetushino",
+        "time": "09:00"
+      },
+      "parkrun Shuvalovsky Park": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Shuvalovsky Park",
+        "shortname": "shuvalovskypark",
+        "time": "10:00"
+      },
+      "parkrun Sosnovka": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Sosnovka",
+        "shortname": "sosnovka",
+        "time": "09:00"
+      },
+      "parkrun Timiryazevsky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Timiryazevsky",
+        "shortname": "timiryazevsky",
+        "time": "10:00"
+      },
+      "parkrun Vernadskogo": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Vernadskogo",
+        "shortname": "vernadskogo",
+        "time": "10:00"
+      },
+      "parkrun Volgograd Panorama": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Volgograd Panorama",
+        "shortname": "volgogradpanorama",
+        "time": "10:00"
+      },
+      "parkrun Voronezh Central Park": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Voronezh Central Park",
+        "shortname": "voronezhcentralpark",
+        "time": "10:00"
+      },
+      "parkrun Yakutsk Dokhsun": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Yakutsk Dokhsun",
+        "shortname": "yakutskdokhsun",
+        "time": "09:00"
+      },
+      "parkrun Zelenograd": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Zelenograd",
+        "shortname": "zelenograd",
+        "time": "10:00"
+      },
+      "parkrun Zhukovsky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Zhukovsky",
+        "shortname": "zhukovsky",
+        "time": "09:00"
+      }
+    },
+    "index": 3
+  },
+  "Tag der Deutschen Einheit": {
+    "date": null,
+    "events": {
+      "Georgengarten parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Georgengarten parkrun",
+        "shortname": "georgengarten",
+        "time": "09:00"
+      },
+      "Hasenheide parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Hasenheide parkrun",
+        "shortname": "hasenheide",
+        "time": "09:00"
+      },
+      "K\u00fcchenholz parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "K\u00fcchenholz parkrun",
+        "shortname": "kuechenholz",
+        "time": "09:00"
+      },
+      "Leinpfad parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Leinpfad parkrun",
+        "shortname": "leinpfad",
+        "time": "09:00"
+      },
+      "Neckarau parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Neckarau parkrun",
+        "shortname": "neckarau",
+        "time": "09:00"
+      },
+      "Neckarufer parkrun, Esslingen": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Neckarufer parkrun, Esslingen",
+        "shortname": "neckaruferesslingen",
+        "time": "09:00"
+      },
+      "Riemer parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Riemer parkrun",
+        "shortname": "riemer",
+        "time": "09:00"
+      },
+      "Rubbenbruchsee parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Rubbenbruchsee parkrun",
+        "shortname": "rubbenbruchsee",
+        "time": "09:00"
+      },
+      "Schwanenteich parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Schwanenteich parkrun",
+        "shortname": "schwanenteich",
+        "time": "09:00"
+      },
+      "Seewoog parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Seewoog parkrun",
+        "shortname": "seewoog",
+        "time": "09:00"
+      },
+      "Unisee parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Unisee parkrun",
+        "shortname": "unisee",
+        "time": "09:00"
+      },
+      "Volksgarten parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Volksgarten parkrun",
+        "shortname": "volksgarten",
+        "time": "09:00"
+      },
+      "Westpark parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Westpark parkrun",
+        "shortname": "westpark",
+        "time": "09:00"
+      }
+    },
+    "index": 3
+  },
+  "Thanksgiving": {
+    "date": "2018-11-28",
+    "events": {
+      "Clermont Waterfront parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Clermont Waterfront parkrun",
+        "shortname": "clermontwaterfront",
+        "time": "07:30"
+      },
+      "College Park parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "College Park parkrun",
+        "shortname": "collegepark",
+        "time": "09:00"
+      },
+      "Delaware and Raritan Canal parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Delaware and Raritan Canal parkrun",
+        "shortname": "delawareandraritancanal",
+        "time": "09:00"
+      },
+      "Eagan parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Eagan parkrun",
+        "shortname": "eagan",
+        "time": "09:00"
+      },
+      "Jamaica Pond parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Jamaica Pond parkrun",
+        "shortname": "jamaicapond",
+        "time": "09:00"
+      },
+      "Kensington parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Kensington parkrun",
+        "shortname": "kensington",
+        "time": "09:00"
+      },
+      "Lillie parkrun, Ann Arbor": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Lillie parkrun, Ann Arbor",
+        "shortname": "lillie",
+        "time": "09:00"
+      },
+      "Livonia parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Livonia parkrun",
+        "shortname": "livonia",
+        "time": "09:00"
+      },
+      "Oak Grove parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Oak Grove parkrun",
+        "shortname": "oakgrove",
+        "time": "09:00"
+      },
+      "Perrigo parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Perrigo parkrun",
+        "shortname": "perrigo",
+        "time": "09:00"
+      },
+      "Rec Plex North parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Rec Plex North parkrun",
+        "shortname": "recplexnorth",
+        "time": "07:30"
+      },
+      "Terry Hershey parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Terry Hershey parkrun",
+        "shortname": "terryhershey",
+        "time": "09:00"
+      }
+    },
+    "index": 2
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/au.json
+++ b/data/parkrun-special-events/2019-20/parsed/au.json
@@ -1,0 +1,322 @@
+{
+  "Christmas Day": {
+    "date": "2019-12-25",
+    "events": {
+      "Balyang Sanctuary parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Balyang Sanctuary parkrun",
+        "shortname": "balyangsanctuary",
+        "time": "08:00"
+      },
+      "Bibra Lake parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Bibra Lake parkrun",
+        "shortname": "bibralake",
+        "time": "08:00"
+      },
+      "Cairns parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Cairns parkrun",
+        "shortname": "cairns",
+        "time": "07:00"
+      },
+      "Dubbo parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Dubbo parkrun",
+        "shortname": "dubbo",
+        "time": "08:00"
+      },
+      "Euroa parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Euroa parkrun",
+        "shortname": "euroa",
+        "time": "08:00"
+      },
+      "Fingal Bay parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Fingal Bay parkrun",
+        "shortname": "fingalbay",
+        "time": "08:00"
+      },
+      "Goulburn parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Goulburn parkrun",
+        "shortname": "goulburn",
+        "time": "08:00"
+      },
+      "Greenbank parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Greenbank parkrun",
+        "shortname": "greenbank",
+        "time": "07:00"
+      },
+      "Highfields parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Highfields parkrun",
+        "shortname": "highfields",
+        "time": "07:00"
+      },
+      "Inverloch parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Inverloch parkrun",
+        "shortname": "inverloch",
+        "time": "08:00"
+      },
+      "Montrose Foreshore parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Montrose Foreshore parkrun",
+        "shortname": "montroseforeshore",
+        "time": "09:00"
+      },
+      "Newport Lakes parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Newport Lakes parkrun",
+        "shortname": "newportlakes",
+        "time": "08:00"
+      },
+      "North Shore parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "North Shore parkrun",
+        "shortname": "northshore",
+        "time": "07:00"
+      },
+      "Sandgate parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Sandgate parkrun",
+        "shortname": "sandgate",
+        "time": "07:00"
+      },
+      "Seacliff Esplanade parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Seacliff Esplanade parkrun",
+        "shortname": "seacliffesplanade",
+        "time": "08:00"
+      },
+      "Studley parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Studley parkrun",
+        "shortname": "studley",
+        "time": "08:00"
+      },
+      "The Ponds parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "The Ponds parkrun",
+        "shortname": "theponds",
+        "time": "08:00"
+      },
+      "Wyndham Vale parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Wyndham Vale parkrun",
+        "shortname": "wyndhamvale",
+        "time": "08:00"
+      }
+    },
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {
+      "Balyang Sanctuary parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Balyang Sanctuary parkrun",
+        "shortname": "balyangsanctuary",
+        "time": "07:30"
+      },
+      "Bibra Lake parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Bibra Lake parkrun",
+        "shortname": "bibralake",
+        "time": "09:30"
+      },
+      "Bowral parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Bowral parkrun",
+        "shortname": "bowral",
+        "time": "09:30"
+      },
+      "Cairns parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Cairns parkrun",
+        "shortname": "cairns",
+        "time": "07:00"
+      },
+      "Calleya parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Calleya parkrun",
+        "shortname": "calleya",
+        "time": "07:30"
+      },
+      "Campbelltown parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Campbelltown parkrun",
+        "shortname": "campbelltown",
+        "time": "07:00"
+      },
+      "Carisbrooke parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Carisbrooke parkrun",
+        "shortname": "carisbrooke",
+        "time": "09:30"
+      },
+      "Dubbo parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Dubbo parkrun",
+        "shortname": "dubbo",
+        "time": "08:00"
+      },
+      "Fingal Bay parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Fingal Bay parkrun",
+        "shortname": "fingalbay",
+        "time": "08:00"
+      },
+      "Forest Lake parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Forest Lake parkrun",
+        "shortname": "forestlake",
+        "time": "08:30"
+      },
+      "Hervey Bay parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Hervey Bay parkrun",
+        "shortname": "herveybay",
+        "time": "06:30"
+      },
+      "Highfields parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Highfields parkrun",
+        "shortname": "highfields",
+        "time": "08:30"
+      },
+      "Hobart parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Hobart parkrun",
+        "shortname": "hobart",
+        "time": "08:30"
+      },
+      "Mernda parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Mernda parkrun",
+        "shortname": "mernda",
+        "time": "08:00"
+      },
+      "Montrose Foreshore parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Montrose Foreshore parkrun",
+        "shortname": "montroseforeshore",
+        "time": "10:30"
+      },
+      "Mullum Mullum parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Mullum Mullum parkrun",
+        "shortname": "mullummullum",
+        "time": "09:30"
+      },
+      "North Shore parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "North Shore parkrun",
+        "shortname": "northshore",
+        "time": "08:00"
+      },
+      "Pakenham parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Pakenham parkrun",
+        "shortname": "pakenham",
+        "time": "08:00"
+      },
+      "Redland Bay parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Redland Bay parkrun",
+        "shortname": "redlandbay",
+        "time": "07:00"
+      },
+      "Rocks Riverside parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Rocks Riverside parkrun",
+        "shortname": "rocksriverside",
+        "time": "08:30"
+      },
+      "Sandgate parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Sandgate parkrun",
+        "shortname": "sandgate",
+        "time": "07:00"
+      },
+      "Seacliff Esplanade parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Seacliff Esplanade parkrun",
+        "shortname": "seacliffesplanade",
+        "time": "09:30"
+      },
+      "St Lucia parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "St Lucia parkrun",
+        "shortname": "stlucia",
+        "time": "07:00"
+      },
+      "The Ponds parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "The Ponds parkrun",
+        "shortname": "theponds",
+        "time": "09:00"
+      },
+      "Woodbridge Riverside parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Woodbridge Riverside parkrun",
+        "shortname": "woodbridgeriverside",
+        "time": "09:00"
+      },
+      "Wyndham Vale parkrun": {
+        "country_code": "au",
+        "country_domain": "www.parkrun.com.au",
+        "longname": "Wyndham Vale parkrun",
+        "shortname": "wyndhamvale",
+        "time": "09:30"
+      }
+    },
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/ca.json
+++ b/data/parkrun-special-events/2019-20/parsed/ca.json
@@ -1,0 +1,7 @@
+{
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 2
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/de.json
+++ b/data/parkrun-special-events/2019-20/parsed/de.json
@@ -1,0 +1,104 @@
+{
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 2
+  },
+  "Tag der Deutschen Einheit": {
+    "date": null,
+    "events": {
+      "Georgengarten parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Georgengarten parkrun",
+        "shortname": "georgengarten",
+        "time": "09:00"
+      },
+      "Hasenheide parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Hasenheide parkrun",
+        "shortname": "hasenheide",
+        "time": "09:00"
+      },
+      "K\u00fcchenholz parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "K\u00fcchenholz parkrun",
+        "shortname": "kuechenholz",
+        "time": "09:00"
+      },
+      "Leinpfad parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Leinpfad parkrun",
+        "shortname": "leinpfad",
+        "time": "09:00"
+      },
+      "Neckarau parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Neckarau parkrun",
+        "shortname": "neckarau",
+        "time": "09:00"
+      },
+      "Neckarufer parkrun, Esslingen": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Neckarufer parkrun, Esslingen",
+        "shortname": "neckaruferesslingen",
+        "time": "09:00"
+      },
+      "Riemer parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Riemer parkrun",
+        "shortname": "riemer",
+        "time": "09:00"
+      },
+      "Rubbenbruchsee parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Rubbenbruchsee parkrun",
+        "shortname": "rubbenbruchsee",
+        "time": "09:00"
+      },
+      "Schwanenteich parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Schwanenteich parkrun",
+        "shortname": "schwanenteich",
+        "time": "09:00"
+      },
+      "Seewoog parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Seewoog parkrun",
+        "shortname": "seewoog",
+        "time": "09:00"
+      },
+      "Unisee parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Unisee parkrun",
+        "shortname": "unisee",
+        "time": "09:00"
+      },
+      "Volksgarten parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Volksgarten parkrun",
+        "shortname": "volksgarten",
+        "time": "09:00"
+      },
+      "Westpark parkrun": {
+        "country_code": "de",
+        "country_domain": "www.parkrun.com.de",
+        "longname": "Westpark parkrun",
+        "shortname": "westpark",
+        "time": "09:00"
+      }
+    },
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/dk.json
+++ b/data/parkrun-special-events/2019-20/parsed/dk.json
@@ -1,0 +1,12 @@
+{
+  "Christmas Eve": {
+    "date": "2019-12-24",
+    "events": {},
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/fi.json
+++ b/data/parkrun-special-events/2019-20/parsed/fi.json
@@ -1,0 +1,12 @@
+{
+  "Christmas Eve": {
+    "date": "2019-12-24",
+    "events": {},
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/fr.json
+++ b/data/parkrun-special-events/2019-20/parsed/fr.json
@@ -1,0 +1,12 @@
+{
+  "Christmas Day": {
+    "date": "2019-12-25",
+    "events": {},
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/ie.json
+++ b/data/parkrun-special-events/2019-20/parsed/ie.json
@@ -1,0 +1,91 @@
+{
+  "Christmas Day": {
+    "date": "2019-12-25",
+    "events": {
+      "Ballincollig parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Ballincollig parkrun",
+        "shortname": "ballincollig",
+        "time": "09:30"
+      },
+      "Clonmel parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Clonmel parkrun",
+        "shortname": "clonmel",
+        "time": "09:30"
+      },
+      "Malahide parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Malahide parkrun",
+        "shortname": "malahide",
+        "time": "09:30"
+      },
+      "Tralee parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Tralee parkrun",
+        "shortname": "tralee",
+        "time": "09:30"
+      }
+    },
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {
+      "Ballincollig parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Ballincollig parkrun",
+        "shortname": "ballincollig",
+        "time": "09:30"
+      },
+      "Brickfields parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Brickfields parkrun",
+        "shortname": "brickfields",
+        "time": "11:00"
+      },
+      "Clonmel parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Clonmel parkrun",
+        "shortname": "clonmel",
+        "time": "11:00"
+      },
+      "Glen River parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Glen River parkrun",
+        "shortname": "glenriver",
+        "time": "11:00"
+      },
+      "Listowel parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Listowel parkrun",
+        "shortname": "listowel",
+        "time": "09:00"
+      },
+      "Royal Canal parkrun, Kilcock": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Royal Canal parkrun, Kilcock",
+        "shortname": "royalcanalkilcock",
+        "time": "11:00"
+      },
+      "Tralee parkrun": {
+        "country_code": "ie",
+        "country_domain": "www.parkrun.ie",
+        "longname": "Tralee parkrun",
+        "shortname": "tralee",
+        "time": "11:00"
+      }
+    },
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/it.json
+++ b/data/parkrun-special-events/2019-20/parsed/it.json
@@ -1,0 +1,12 @@
+{
+  "Christmas Day": {
+    "date": "2019-12-25",
+    "events": {},
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/my.json
+++ b/data/parkrun-special-events/2019-20/parsed/my.json
@@ -1,0 +1,7 @@
+{
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 2
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/no.json
+++ b/data/parkrun-special-events/2019-20/parsed/no.json
@@ -1,0 +1,12 @@
+{
+  "Christmas Eve": {
+    "date": "2019-12-24",
+    "events": {},
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/nz.json
+++ b/data/parkrun-special-events/2019-20/parsed/nz.json
@@ -1,0 +1,91 @@
+{
+  "Christmas Day": {
+    "date": "2019-12-25",
+    "events": {
+      "Anderson parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Anderson parkrun",
+        "shortname": "anderson",
+        "time": "08:00"
+      },
+      "Flaxmere parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Flaxmere parkrun",
+        "shortname": "flaxmere",
+        "time": "08:00"
+      },
+      "Gisborne parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Gisborne parkrun",
+        "shortname": "gisborne",
+        "time": "08:00"
+      },
+      "Greytown Woodside Trail parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Greytown Woodside Trail parkrun",
+        "shortname": "greytownwoodsidetrail",
+        "time": "08:00"
+      },
+      "Hobsonville Point parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Hobsonville Point parkrun",
+        "shortname": "hobsonvillepoint",
+        "time": "08:00"
+      },
+      "Pegasus parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Pegasus parkrun",
+        "shortname": "pegasus",
+        "time": "08:00"
+      },
+      "Whangarei parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Whangarei parkrun",
+        "shortname": "whangarei",
+        "time": "08:00"
+      }
+    },
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {
+      "Anderson parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Anderson parkrun",
+        "shortname": "anderson",
+        "time": "08:00"
+      },
+      "Flaxmere parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Flaxmere parkrun",
+        "shortname": "flaxmere",
+        "time": "09:30"
+      },
+      "Gisborne parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Gisborne parkrun",
+        "shortname": "gisborne",
+        "time": "09:00"
+      },
+      "Hobsonville Point parkrun": {
+        "country_code": "nz",
+        "country_domain": "www.parkrun.co.nz",
+        "longname": "Hobsonville Point parkrun",
+        "shortname": "hobsonvillepoint",
+        "time": "09:30"
+      }
+    },
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/pl.json
+++ b/data/parkrun-special-events/2019-20/parsed/pl.json
@@ -1,0 +1,35 @@
+{
+  "Boxing Day": {
+    "date": "2019-12-26",
+    "events": {
+      "parkrun Kedzierzyn-Kozle": {
+        "country_code": "pl",
+        "country_domain": "www.parkrun.pl",
+        "longname": "parkrun Kedzierzyn-Kozle",
+        "shortname": "kedzierzyn-kozle",
+        "time": "09:00"
+      },
+      "parkrun Warszawa-Ursynow": {
+        "country_code": "pl",
+        "country_domain": "www.parkrun.pl",
+        "longname": "parkrun Warszawa-Ursynow",
+        "shortname": "warszawa-ursynow",
+        "time": "09:00"
+      }
+    },
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {
+      "parkrun Kedzierzyn-Kozle": {
+        "country_code": "pl",
+        "country_domain": "www.parkrun.pl",
+        "longname": "parkrun Kedzierzyn-Kozle",
+        "shortname": "kedzierzyn-kozle",
+        "time": "10:00"
+      }
+    },
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/ru.json
+++ b/data/parkrun-special-events/2019-20/parsed/ru.json
@@ -1,0 +1,230 @@
+{
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 2
+  },
+  "Orthodox Christmas": {
+    "date": "2020-01-07",
+    "events": {
+      "parkrun Butovo": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Butovo",
+        "shortname": "butovo",
+        "time": "09:00"
+      },
+      "parkrun Cheboksary naberezhnaya": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Cheboksary naberezhnaya",
+        "shortname": "cheboksarynaberezhnaya",
+        "time": "10:00"
+      },
+      "parkrun Chelyabinsk": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Chelyabinsk",
+        "shortname": "chelyabinsk",
+        "time": "09:00"
+      },
+      "parkrun Dolgoprudny": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Dolgoprudny",
+        "shortname": "dolgoprudny",
+        "time": "10:00"
+      },
+      "parkrun Ekaterinburg Zelenaya Roscha": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Ekaterinburg Zelenaya Roscha",
+        "shortname": "ekaterinburgzelenayaroscha",
+        "time": "10:00"
+      },
+      "parkrun Elagin Ostrov": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Elagin Ostrov",
+        "shortname": "elaginostrov",
+        "time": "10:00"
+      },
+      "parkrun Khimki": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Khimki",
+        "shortname": "khimki",
+        "time": "10:00"
+      },
+      "parkrun Kimry": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Kimry",
+        "shortname": "kimry",
+        "time": "09:00"
+      },
+      "parkrun Kolomenskoe": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Kolomenskoe",
+        "shortname": "kolomenskoe",
+        "time": "10:00"
+      },
+      "parkrun Kolpino": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Kolpino",
+        "shortname": "kolpino",
+        "time": "10:00"
+      },
+      "parkrun Krylatskoe": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Krylatskoe",
+        "shortname": "krylatskoe",
+        "time": "09:00"
+      },
+      "parkrun Kuzminki": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Kuzminki",
+        "shortname": "kuzminki",
+        "time": "09:00"
+      },
+      "parkrun Mega Park Kudrovo": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Mega Park Kudrovo",
+        "shortname": "megaparkkudrovo",
+        "time": "09:30"
+      },
+      "parkrun Meshchersky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Meshchersky",
+        "shortname": "meshchersky",
+        "time": "09:00"
+      },
+      "parkrun Natashinsky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Natashinsky",
+        "shortname": "natashinsky",
+        "time": "10:00"
+      },
+      "parkrun Olimpiyskaya Derevnya": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Olimpiyskaya Derevnya",
+        "shortname": "olimpiyskayaderevnya",
+        "time": "09:00"
+      },
+      "parkrun Pavlovsky Posad": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Pavlovsky Posad",
+        "shortname": "pavlovskyposad",
+        "time": "09:00"
+      },
+      "parkrun Perm Balatovo": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Perm Balatovo",
+        "shortname": "permbalatovo",
+        "time": "10:00"
+      },
+      "parkrun Petergof Aleksandriysky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Petergof Aleksandriysky",
+        "shortname": "petergofaleksandriysky",
+        "time": "10:00"
+      },
+      "parkrun Pushkin": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Pushkin",
+        "shortname": "pushkin",
+        "time": "10:00"
+      },
+      "parkrun Samara Park Gagarina": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Samara Park Gagarina",
+        "shortname": "samaraparkgagarina",
+        "time": "10:00"
+      },
+      "parkrun Severnoe Tushino": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Severnoe Tushino",
+        "shortname": "severnoetushino",
+        "time": "09:00"
+      },
+      "parkrun Shuvalovsky Park": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Shuvalovsky Park",
+        "shortname": "shuvalovskypark",
+        "time": "10:00"
+      },
+      "parkrun Sosnovka": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Sosnovka",
+        "shortname": "sosnovka",
+        "time": "09:00"
+      },
+      "parkrun Timiryazevsky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Timiryazevsky",
+        "shortname": "timiryazevsky",
+        "time": "10:00"
+      },
+      "parkrun Vernadskogo": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Vernadskogo",
+        "shortname": "vernadskogo",
+        "time": "10:00"
+      },
+      "parkrun Volgograd Panorama": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Volgograd Panorama",
+        "shortname": "volgogradpanorama",
+        "time": "10:00"
+      },
+      "parkrun Voronezh Central Park": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Voronezh Central Park",
+        "shortname": "voronezhcentralpark",
+        "time": "10:00"
+      },
+      "parkrun Yakutsk Dokhsun": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Yakutsk Dokhsun",
+        "shortname": "yakutskdokhsun",
+        "time": "09:00"
+      },
+      "parkrun Zelenograd": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Zelenograd",
+        "shortname": "zelenograd",
+        "time": "10:00"
+      },
+      "parkrun Zhukovsky": {
+        "country_code": "ru",
+        "country_domain": "www.parkrun.ru",
+        "longname": "parkrun Zhukovsky",
+        "shortname": "zhukovsky",
+        "time": "09:00"
+      }
+    },
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/se.json
+++ b/data/parkrun-special-events/2019-20/parsed/se.json
@@ -1,0 +1,7 @@
+{
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 2
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/sg.json
+++ b/data/parkrun-special-events/2019-20/parsed/sg.json
@@ -1,0 +1,12 @@
+{
+  "Chinese New Year": {
+    "date": "2020-01-20",
+    "events": {},
+    "index": 3
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {},
+    "index": 2
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/uk.json
+++ b/data/parkrun-special-events/2019-20/parsed/uk.json
@@ -1,0 +1,1638 @@
+{
+  "Christmas Day": {
+    "date": "2019-12-25",
+    "events": {
+      "Albert parkrun, Middlesbrough": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Albert parkrun, Middlesbrough",
+        "shortname": "albert",
+        "time": "09:00"
+      },
+      "Aylesbury parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Aylesbury parkrun",
+        "shortname": "aylesbury",
+        "time": "09:00"
+      },
+      "Barking parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Barking parkrun",
+        "shortname": "barking",
+        "time": "09:00"
+      },
+      "Barry Island parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Barry Island parkrun",
+        "shortname": "barryisland",
+        "time": "09:00"
+      },
+      "Basildon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Basildon parkrun",
+        "shortname": "basildon",
+        "time": "09:00"
+      },
+      "Basingstoke parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Basingstoke parkrun",
+        "shortname": "basingstoke",
+        "time": "09:00"
+      },
+      "Bedford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bedford parkrun",
+        "shortname": "bedford",
+        "time": "09:00"
+      },
+      "Beeston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Beeston parkrun",
+        "shortname": "beeston",
+        "time": "09:00"
+      },
+      "Bethlem Royal Hospital parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bethlem Royal Hospital parkrun",
+        "shortname": "bethlemroyalhospital",
+        "time": "09:00"
+      },
+      "Bexley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bexley parkrun",
+        "shortname": "bexley",
+        "time": "09:00"
+      },
+      "Bicester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bicester parkrun",
+        "shortname": "bicester",
+        "time": "09:00"
+      },
+      "Billericay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Billericay parkrun",
+        "shortname": "billericay",
+        "time": "09:00"
+      },
+      "Blandford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Blandford parkrun",
+        "shortname": "blandford",
+        "time": "09:00"
+      },
+      "Blyth Links parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Blyth Links parkrun",
+        "shortname": "blythlinks",
+        "time": "09:00"
+      },
+      "Boston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Boston parkrun",
+        "shortname": "boston",
+        "time": "09:00"
+      },
+      "Braunstone parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Braunstone parkrun",
+        "shortname": "braunstone",
+        "time": "09:00"
+      },
+      "Buckingham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Buckingham parkrun",
+        "shortname": "buckingham",
+        "time": "09:00"
+      },
+      "Catford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Catford parkrun",
+        "shortname": "catford",
+        "time": "09:00"
+      },
+      "Chichester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chichester parkrun",
+        "shortname": "chichester",
+        "time": "09:00"
+      },
+      "Chippenham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chippenham parkrun",
+        "shortname": "chippenham",
+        "time": "09:00"
+      },
+      "Clair parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Clair parkrun",
+        "shortname": "clair",
+        "time": "09:00"
+      },
+      "Cleethorpes parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Cleethorpes parkrun",
+        "shortname": "cleethorpes",
+        "time": "09:00"
+      },
+      "Cliffe Castle parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Cliffe Castle parkrun",
+        "shortname": "cliffecastle",
+        "time": "09:00"
+      },
+      "Colchester junior parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Colchester junior parkrun",
+        "shortname": "colchester-juniors",
+        "time": "09:00"
+      },
+      "Conkers parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Conkers parkrun",
+        "shortname": "conkers",
+        "time": "09:00"
+      },
+      "Darlington South Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Darlington South Park parkrun",
+        "shortname": "darlingtonsouthpark",
+        "time": "09:00"
+      },
+      "Daventry parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Daventry parkrun",
+        "shortname": "daventry",
+        "time": "09:00"
+      },
+      "Delamere parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Delamere parkrun",
+        "shortname": "delamere",
+        "time": "09:00"
+      },
+      "Doncaster parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Doncaster parkrun",
+        "shortname": "doncaster",
+        "time": "09:00"
+      },
+      "Eastbourne parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Eastbourne parkrun",
+        "shortname": "eastbourne",
+        "time": "09:00"
+      },
+      "Elgin parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Elgin parkrun",
+        "shortname": "elgin",
+        "time": "09:30"
+      },
+      "Exeter Riverside parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Exeter Riverside parkrun",
+        "shortname": "exeterriverside",
+        "time": "09:00"
+      },
+      "Fareham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Fareham parkrun",
+        "shortname": "fareham",
+        "time": "09:00"
+      },
+      "Forest Rec parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Forest Rec parkrun",
+        "shortname": "forestrec",
+        "time": "09:00"
+      },
+      "Forest of Dean parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Forest of Dean parkrun",
+        "shortname": "forest-of-dean",
+        "time": "09:00"
+      },
+      "Frimley Lodge parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Frimley Lodge parkrun",
+        "shortname": "frimleylodge",
+        "time": "09:00"
+      },
+      "Great Lines parkrun, Medway": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Great Lines parkrun, Medway",
+        "shortname": "greatlines",
+        "time": "09:00"
+      },
+      "Great Notley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Great Notley parkrun",
+        "shortname": "greatnotley",
+        "time": "09:00"
+      },
+      "Greenwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Greenwich parkrun",
+        "shortname": "greenwich",
+        "time": "09:00"
+      },
+      "Grovelands parkrun, Enfield": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Grovelands parkrun, Enfield",
+        "shortname": "grovelands",
+        "time": "09:00"
+      },
+      "Guildford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Guildford parkrun",
+        "shortname": "guildford",
+        "time": "09:00"
+      },
+      "Hadleigh parkrun, Essex": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hadleigh parkrun, Essex",
+        "shortname": "hadleigh",
+        "time": "09:00"
+      },
+      "Harlow parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Harlow parkrun",
+        "shortname": "harlow",
+        "time": "09:00"
+      },
+      "Hartlepool parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hartlepool parkrun",
+        "shortname": "hartlepool",
+        "time": "09:00"
+      },
+      "Heartlands parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Heartlands parkrun",
+        "shortname": "heartlands",
+        "time": "09:00"
+      },
+      "Henstridge Airfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Henstridge Airfield parkrun",
+        "shortname": "henstridgeairfield",
+        "time": "09:00"
+      },
+      "Herrington Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Herrington Country parkrun",
+        "shortname": "herringtoncountry",
+        "time": "09:00"
+      },
+      "Highbury Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Highbury Fields parkrun",
+        "shortname": "highburyfields",
+        "time": "09:00"
+      },
+      "Homewood parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Homewood parkrun",
+        "shortname": "homewood",
+        "time": "09:00"
+      },
+      "Huddersfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Huddersfield parkrun",
+        "shortname": "huddersfield",
+        "time": "09:00"
+      },
+      "Hull parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hull parkrun",
+        "shortname": "hull",
+        "time": "09:00"
+      },
+      "Huntingdon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Huntingdon parkrun",
+        "shortname": "huntingdon",
+        "time": "09:00"
+      },
+      "Jersey parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Jersey parkrun",
+        "shortname": "jersey",
+        "time": "09:00"
+      },
+      "Lee-on-the-Solent parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Lee-on-the-Solent parkrun",
+        "shortname": "leeonthesolent",
+        "time": "09:00"
+      },
+      "Lincoln parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Lincoln parkrun",
+        "shortname": "lincoln",
+        "time": "09:00"
+      },
+      "Linwood parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Linwood parkrun",
+        "shortname": "linwood",
+        "time": "09:30"
+      },
+      "Livingston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Livingston parkrun",
+        "shortname": "livingston",
+        "time": "09:30"
+      },
+      "Maldon Prom parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Maldon Prom parkrun",
+        "shortname": "maldonprom",
+        "time": "09:00"
+      },
+      "Malling parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Malling parkrun",
+        "shortname": "malling",
+        "time": "09:00"
+      },
+      "Melton Mowbray parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Melton Mowbray parkrun",
+        "shortname": "meltonmowbray",
+        "time": "09:00"
+      },
+      "Millfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Millfield parkrun",
+        "shortname": "millfield",
+        "time": "09:00"
+      },
+      "Milton Keynes parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Milton Keynes parkrun",
+        "shortname": "miltonkeynes",
+        "time": "09:00"
+      },
+      "Netley Abbey parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Netley Abbey parkrun",
+        "shortname": "netleyabbey",
+        "time": "09:00"
+      },
+      "Newark parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Newark parkrun",
+        "shortname": "newark",
+        "time": "09:00"
+      },
+      "Northala Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Northala Fields parkrun",
+        "shortname": "northalafields",
+        "time": "09:00"
+      },
+      "Northallerton parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Northallerton parkrun",
+        "shortname": "northallerton",
+        "time": "09:00"
+      },
+      "Northwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Northwich parkrun",
+        "shortname": "northwich",
+        "time": "09:00"
+      },
+      "Norwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Norwich parkrun",
+        "shortname": "norwich",
+        "time": "09:00"
+      },
+      "Oak Hill parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Oak Hill parkrun",
+        "shortname": "oak-hill",
+        "time": "09:00"
+      },
+      "Old Deer Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Old Deer Park parkrun",
+        "shortname": "olddeerpark",
+        "time": "09:00"
+      },
+      "Panshanger parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Panshanger parkrun",
+        "shortname": "panshanger",
+        "time": "09:00"
+      },
+      "Poole parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Poole parkrun",
+        "shortname": "poole",
+        "time": "09:00"
+      },
+      "Poolsbrook parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Poolsbrook parkrun",
+        "shortname": "poolsbrook",
+        "time": "09:00"
+      },
+      "Portrush junior parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Portrush junior parkrun",
+        "shortname": "portrush-juniors",
+        "time": "09:30"
+      },
+      "Preston Park parkrun, Brighton": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Preston Park parkrun, Brighton",
+        "shortname": "prestonpark",
+        "time": "09:00"
+      },
+      "Preston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Preston parkrun",
+        "shortname": "preston",
+        "time": "09:00"
+      },
+      "Prospect parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Prospect parkrun",
+        "shortname": "prospect",
+        "time": "09:00"
+      },
+      "Richmond parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Richmond parkrun",
+        "shortname": "richmond",
+        "time": "09:00"
+      },
+      "Roundhay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Roundhay parkrun",
+        "shortname": "roundhay",
+        "time": "09:00"
+      },
+      "Royal Tunbridge Wells parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Royal Tunbridge Wells parkrun",
+        "shortname": "royaltunbridgewells",
+        "time": "09:00"
+      },
+      "Selby parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Selby parkrun",
+        "shortname": "selby",
+        "time": "09:00"
+      },
+      "Severn Valley Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Severn Valley Country parkrun",
+        "shortname": "severnvalleycountry",
+        "time": "09:00"
+      },
+      "Shrewsbury parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Shrewsbury parkrun",
+        "shortname": "shrewsbury",
+        "time": "09:00"
+      },
+      "South Manchester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "South Manchester parkrun",
+        "shortname": "southmanchester",
+        "time": "09:00"
+      },
+      "South Woodham Ferrers parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "South Woodham Ferrers parkrun",
+        "shortname": "southwoodhamferrers",
+        "time": "09:00"
+      },
+      "Southsea parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southsea parkrun",
+        "shortname": "southsea",
+        "time": "09:00"
+      },
+      "Southwark parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southwark parkrun",
+        "shortname": "southwark",
+        "time": "09:00"
+      },
+      "St Albans parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "St Albans parkrun",
+        "shortname": "stalbans",
+        "time": "09:00"
+      },
+      "St Helens parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "St Helens parkrun",
+        "shortname": "sthelens",
+        "time": "09:00"
+      },
+      "Stonehaven parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Stonehaven parkrun",
+        "shortname": "stonehaven",
+        "time": "09:30"
+      },
+      "Street parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Street parkrun",
+        "shortname": "street",
+        "time": "09:00"
+      },
+      "The Wammy parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "The Wammy parkrun",
+        "shortname": "thewammy",
+        "time": "09:00"
+      },
+      "Tring parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Tring parkrun",
+        "shortname": "tring",
+        "time": "09:00"
+      },
+      "Troon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Troon parkrun",
+        "shortname": "troon",
+        "time": "09:30"
+      },
+      "Wallace parkrun, Lisburn": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Wallace parkrun, Lisburn",
+        "shortname": "wallace",
+        "time": "09:30"
+      },
+      "Walmer and Deal Seafront parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Walmer and Deal Seafront parkrun",
+        "shortname": "walmeranddealseafront",
+        "time": "09:00"
+      },
+      "Walsall Arboretum parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Walsall Arboretum parkrun",
+        "shortname": "walsall",
+        "time": "09:00"
+      },
+      "Whiteley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Whiteley parkrun",
+        "shortname": "whiteley",
+        "time": "09:00"
+      },
+      "Whitstable parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Whitstable parkrun",
+        "shortname": "whitstable",
+        "time": "09:00"
+      },
+      "Widnes parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Widnes parkrun",
+        "shortname": "widnes",
+        "time": "09:00"
+      },
+      "Wilmslow parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Wilmslow parkrun",
+        "shortname": "wilmslow",
+        "time": "09:00"
+      },
+      "Witton parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Witton parkrun",
+        "shortname": "witton",
+        "time": "09:00"
+      },
+      "Woodhouse Moor parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Woodhouse Moor parkrun",
+        "shortname": "woodhousemoor",
+        "time": "09:00"
+      },
+      "Woodley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Woodley parkrun",
+        "shortname": "woodley",
+        "time": "09:00"
+      },
+      "Worcester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Worcester parkrun",
+        "shortname": "worcester",
+        "time": "09:00"
+      },
+      "York parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "York parkrun",
+        "shortname": "york",
+        "time": "09:00"
+      }
+    },
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {
+      "Albert parkrun, Middlesbrough": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Albert parkrun, Middlesbrough",
+        "shortname": "albert",
+        "time": "10:30"
+      },
+      "Barry Island parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Barry Island parkrun",
+        "shortname": "barryisland",
+        "time": "09:00"
+      },
+      "Basingstoke parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Basingstoke parkrun",
+        "shortname": "basingstoke",
+        "time": "09:00"
+      },
+      "Bedford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bedford parkrun",
+        "shortname": "bedford",
+        "time": "09:00"
+      },
+      "Belton House parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Belton House parkrun",
+        "shortname": "beltonhouse",
+        "time": "09:00"
+      },
+      "Bexley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bexley parkrun",
+        "shortname": "bexley",
+        "time": "10:30"
+      },
+      "Billericay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Billericay parkrun",
+        "shortname": "billericay",
+        "time": "09:00"
+      },
+      "Black Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Black Park parkrun",
+        "shortname": "blackpark",
+        "time": "09:00"
+      },
+      "Blackpool parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Blackpool parkrun",
+        "shortname": "blackpool",
+        "time": "10:00"
+      },
+      "Blyth Links parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Blyth Links parkrun",
+        "shortname": "blythlinks",
+        "time": "10:30"
+      },
+      "Bracknell parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Bracknell parkrun",
+        "shortname": "bracknell",
+        "time": "08:30"
+      },
+      "Braunstone parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Braunstone parkrun",
+        "shortname": "braunstone",
+        "time": "10:30"
+      },
+      "Brighton & Hove parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Brighton & Hove parkrun",
+        "shortname": "brighton",
+        "time": "10:30"
+      },
+      "Catford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Catford parkrun",
+        "shortname": "catford",
+        "time": "10:30"
+      },
+      "Chester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chester parkrun",
+        "shortname": "chester",
+        "time": "09:00"
+      },
+      "Chichester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chichester parkrun",
+        "shortname": "chichester",
+        "time": "09:00"
+      },
+      "Chippenham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Chippenham parkrun",
+        "shortname": "chippenham",
+        "time": "10:30"
+      },
+      "Clacton Seafront parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Clacton Seafront parkrun",
+        "shortname": "clactonseafront",
+        "time": "10:30"
+      },
+      "Cliffe Castle parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Cliffe Castle parkrun",
+        "shortname": "cliffecastle",
+        "time": "10:30"
+      },
+      "Colwick parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Colwick parkrun",
+        "shortname": "colwick",
+        "time": "10:30"
+      },
+      "Conkers parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Conkers parkrun",
+        "shortname": "conkers",
+        "time": "09:00"
+      },
+      "Conyngham Hall parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Conyngham Hall parkrun",
+        "shortname": "conynghamhall",
+        "time": "10:30"
+      },
+      "Cotsford Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Cotsford Fields parkrun",
+        "shortname": "cotsfordfields",
+        "time": "09:00"
+      },
+      "Darlington South Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Darlington South Park parkrun",
+        "shortname": "darlingtonsouthpark",
+        "time": "10:30"
+      },
+      "Daventry parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Daventry parkrun",
+        "shortname": "daventry",
+        "time": "10:30"
+      },
+      "Delamere parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Delamere parkrun",
+        "shortname": "delamere",
+        "time": "09:00"
+      },
+      "Eastbourne parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Eastbourne parkrun",
+        "shortname": "eastbourne",
+        "time": "09:00"
+      },
+      "Eden Project parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Eden Project parkrun",
+        "shortname": "edenproject",
+        "time": "09:00"
+      },
+      "Elgin parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Elgin parkrun",
+        "shortname": "elgin",
+        "time": "11:00"
+      },
+      "Ellenbrook Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Ellenbrook Fields parkrun",
+        "shortname": "ellenbrookfields",
+        "time": "10:30"
+      },
+      "Exmouth parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Exmouth parkrun",
+        "shortname": "exmouth",
+        "time": "08:30"
+      },
+      "Fareham parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Fareham parkrun",
+        "shortname": "fareham",
+        "time": "09:00"
+      },
+      "Felixstowe parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Felixstowe parkrun",
+        "shortname": "felixstowe",
+        "time": "10:30"
+      },
+      "Forest of Dean parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Forest of Dean parkrun",
+        "shortname": "forest-of-dean",
+        "time": "10:00"
+      },
+      "Frickley Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Frickley Country parkrun",
+        "shortname": "frickleycountry",
+        "time": "10:30"
+      },
+      "Frimley Lodge parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Frimley Lodge parkrun",
+        "shortname": "frimleylodge",
+        "time": "10:00"
+      },
+      "Gedling parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Gedling parkrun",
+        "shortname": "gedling",
+        "time": "09:00"
+      },
+      "Gladstone parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Gladstone parkrun",
+        "shortname": "gladstone",
+        "time": "10:30"
+      },
+      "Gloucester City parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Gloucester City parkrun",
+        "shortname": "gloucestercity",
+        "time": "10:30"
+      },
+      "Great Notley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Great Notley parkrun",
+        "shortname": "greatnotley",
+        "time": "09:00"
+      },
+      "Greenwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Greenwich parkrun",
+        "shortname": "greenwich",
+        "time": "09:00"
+      },
+      "Grovelands parkrun, Enfield": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Grovelands parkrun, Enfield",
+        "shortname": "grovelands",
+        "time": "09:00"
+      },
+      "Guildford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Guildford parkrun",
+        "shortname": "guildford",
+        "time": "09:00"
+      },
+      "Harrow Lodge parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Harrow Lodge parkrun",
+        "shortname": "harrowlodge",
+        "time": "10:30"
+      },
+      "Hartlepool parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hartlepool parkrun",
+        "shortname": "hartlepool",
+        "time": "10:30"
+      },
+      "Hastings parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hastings parkrun",
+        "shortname": "hastings",
+        "time": "09:00"
+      },
+      "Heartlands parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Heartlands parkrun",
+        "shortname": "heartlands",
+        "time": "08:30"
+      },
+      "Henstridge Airfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Henstridge Airfield parkrun",
+        "shortname": "henstridgeairfield",
+        "time": "09:00"
+      },
+      "Herrington Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Herrington Country parkrun",
+        "shortname": "herringtoncountry",
+        "time": "10:30"
+      },
+      "Highbury Fields parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Highbury Fields parkrun",
+        "shortname": "highburyfields",
+        "time": "09:00"
+      },
+      "Hockley Woods parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hockley Woods parkrun",
+        "shortname": "hockleywoods",
+        "time": "10:30"
+      },
+      "Hove Promenade parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hove Promenade parkrun",
+        "shortname": "hovepromenade",
+        "time": "09:00"
+      },
+      "Huddersfield parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Huddersfield parkrun",
+        "shortname": "huddersfield",
+        "time": "10:30"
+      },
+      "Huntingdon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Huntingdon parkrun",
+        "shortname": "huntingdon",
+        "time": "09:00"
+      },
+      "Hyndburn parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Hyndburn parkrun",
+        "shortname": "hyndburn",
+        "time": "10:30"
+      },
+      "Jersey parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Jersey parkrun",
+        "shortname": "jersey",
+        "time": "10:00"
+      },
+      "Kettering parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Kettering parkrun",
+        "shortname": "kettering",
+        "time": "10:30"
+      },
+      "Killerton parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Killerton parkrun",
+        "shortname": "killerton",
+        "time": "08:30"
+      },
+      "King's Lynn parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "King's Lynn parkrun",
+        "shortname": "kingslynn",
+        "time": "09:00"
+      },
+      "Knowsley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Knowsley parkrun",
+        "shortname": "knowsley",
+        "time": "10:30"
+      },
+      "Lee-on-the-Solent parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Lee-on-the-Solent parkrun",
+        "shortname": "leeonthesolent",
+        "time": "10:30"
+      },
+      "Livingston parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Livingston parkrun",
+        "shortname": "livingston",
+        "time": "11:00"
+      },
+      "Loch Leven parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Loch Leven parkrun",
+        "shortname": "lochleven",
+        "time": "11:00"
+      },
+      "Lytham Hall parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Lytham Hall parkrun",
+        "shortname": "lythamhall",
+        "time": "08:30"
+      },
+      "Maldon Prom parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Maldon Prom parkrun",
+        "shortname": "maldonprom",
+        "time": "09:00"
+      },
+      "Medina I.O.W. parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Medina I.O.W. parkrun",
+        "shortname": "medina",
+        "time": "10:00"
+      },
+      "Melton Mowbray parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Melton Mowbray parkrun",
+        "shortname": "meltonmowbray",
+        "time": "09:00"
+      },
+      "Netley Abbey parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Netley Abbey parkrun",
+        "shortname": "netleyabbey",
+        "time": "09:00"
+      },
+      "Newark parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Newark parkrun",
+        "shortname": "newark",
+        "time": "10:30"
+      },
+      "Newborough Forest parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Newborough Forest parkrun",
+        "shortname": "newboroughforest",
+        "time": "09:00"
+      },
+      "Northwich parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Northwich parkrun",
+        "shortname": "northwich",
+        "time": "10:30"
+      },
+      "Nostell parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Nostell parkrun",
+        "shortname": "nostell",
+        "time": "08:30"
+      },
+      "Oak Hill parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Oak Hill parkrun",
+        "shortname": "oak-hill",
+        "time": "10:30"
+      },
+      "Old Deer Park parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Old Deer Park parkrun",
+        "shortname": "olddeerpark",
+        "time": "09:00"
+      },
+      "Osterley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Osterley parkrun",
+        "shortname": "osterley",
+        "time": "10:30"
+      },
+      "Panshanger parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Panshanger parkrun",
+        "shortname": "panshanger",
+        "time": "09:00"
+      },
+      "Pegwell Bay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Pegwell Bay parkrun",
+        "shortname": "pegwellbay",
+        "time": "10:30"
+      },
+      "Penallta parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Penallta parkrun",
+        "shortname": "penallta",
+        "time": "10:30"
+      },
+      "Pennington Flash parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Pennington Flash parkrun",
+        "shortname": "penningtonflash",
+        "time": "10:30"
+      },
+      "Poolsbrook parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Poolsbrook parkrun",
+        "shortname": "poolsbrook",
+        "time": "10:30"
+      },
+      "Portrush parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Portrush parkrun",
+        "shortname": "portrush",
+        "time": "09:30"
+      },
+      "Prospect parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Prospect parkrun",
+        "shortname": "prospect",
+        "time": "10:30"
+      },
+      "Queen Elizabeth parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Queen Elizabeth parkrun",
+        "shortname": "queenelizabeth",
+        "time": "10:30"
+      },
+      "Ramsbottom junior parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Ramsbottom junior parkrun",
+        "shortname": "ramsbottom-juniors",
+        "time": "10:30"
+      },
+      "Redcar parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Redcar parkrun",
+        "shortname": "redcar",
+        "time": "10:30"
+      },
+      "Richmond parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Richmond parkrun",
+        "shortname": "richmond",
+        "time": "09:00"
+      },
+      "Rothwell parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Rothwell parkrun",
+        "shortname": "rothwell",
+        "time": "10:30"
+      },
+      "Rushmere parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Rushmere parkrun",
+        "shortname": "rushmere",
+        "time": "09:00"
+      },
+      "Selby parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Selby parkrun",
+        "shortname": "selby",
+        "time": "10:30"
+      },
+      "Severn Valley Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Severn Valley Country parkrun",
+        "shortname": "severnvalleycountry",
+        "time": "10:30"
+      },
+      "Shepton Mallet parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Shepton Mallet parkrun",
+        "shortname": "sheptonmallet",
+        "time": "08:30"
+      },
+      "Shipley Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Shipley Country parkrun",
+        "shortname": "shipleycountry",
+        "time": "09:00"
+      },
+      "Shrewsbury parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Shrewsbury parkrun",
+        "shortname": "shrewsbury",
+        "time": "08:30"
+      },
+      "South Manchester parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "South Manchester parkrun",
+        "shortname": "southmanchester",
+        "time": "09:00"
+      },
+      "South Woodham Ferrers parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "South Woodham Ferrers parkrun",
+        "shortname": "southwoodhamferrers",
+        "time": "10:30"
+      },
+      "Southsea parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southsea parkrun",
+        "shortname": "southsea",
+        "time": "09:00"
+      },
+      "Southwark parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southwark parkrun",
+        "shortname": "southwark",
+        "time": "10:30"
+      },
+      "Southwick Country parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Southwick Country parkrun",
+        "shortname": "southwickcountrypark",
+        "time": "09:00"
+      },
+      "Squerryes Winery parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Squerryes Winery parkrun",
+        "shortname": "squerryeswinery",
+        "time": "10:30"
+      },
+      "St Albans parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "St Albans parkrun",
+        "shortname": "stalbans",
+        "time": "10:30"
+      },
+      "St Helens parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "St Helens parkrun",
+        "shortname": "sthelens",
+        "time": "08:30"
+      },
+      "Stonehaven parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Stonehaven parkrun",
+        "shortname": "stonehaven",
+        "time": "11:00"
+      },
+      "Street parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Street parkrun",
+        "shortname": "street",
+        "time": "10:30"
+      },
+      "Stretford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Stretford parkrun",
+        "shortname": "stretford",
+        "time": "10:30"
+      },
+      "Swansea Bay parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Swansea Bay parkrun",
+        "shortname": "swanseabay",
+        "time": "10:30"
+      },
+      "Swindon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Swindon parkrun",
+        "shortname": "swindon",
+        "time": "10:30"
+      },
+      "Telford parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Telford parkrun",
+        "shortname": "telford",
+        "time": "10:30"
+      },
+      "The Wammy parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "The Wammy parkrun",
+        "shortname": "thewammy",
+        "time": "10:30"
+      },
+      "Tring parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Tring parkrun",
+        "shortname": "tring",
+        "time": "09:00"
+      },
+      "Troon parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Troon parkrun",
+        "shortname": "troon",
+        "time": "11:00"
+      },
+      "Upton House parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Upton House parkrun",
+        "shortname": "uptonhouse",
+        "time": "08:30"
+      },
+      "Vogrie parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Vogrie parkrun",
+        "shortname": "vogrie",
+        "time": "11:00"
+      },
+      "Walmer and Deal Seafront parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Walmer and Deal Seafront parkrun",
+        "shortname": "walmeranddealseafront",
+        "time": "08:30"
+      },
+      "Watermeadows parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Watermeadows parkrun",
+        "shortname": "watermeadows",
+        "time": "09:00"
+      },
+      "Wepre parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Wepre parkrun",
+        "shortname": "wepre",
+        "time": "10:30"
+      },
+      "Westmill parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Westmill parkrun",
+        "shortname": "westmill",
+        "time": "10:30"
+      },
+      "Whiteley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Whiteley parkrun",
+        "shortname": "whiteley",
+        "time": "09:00"
+      },
+      "Whitstable parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Whitstable parkrun",
+        "shortname": "whitstable",
+        "time": "09:00"
+      },
+      "Widnes parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Widnes parkrun",
+        "shortname": "widnes",
+        "time": "10:30"
+      },
+      "Wilmslow parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Wilmslow parkrun",
+        "shortname": "wilmslow",
+        "time": "10:30"
+      },
+      "Witney parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Witney parkrun",
+        "shortname": "witney",
+        "time": "09:00"
+      },
+      "Witton parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Witton parkrun",
+        "shortname": "witton",
+        "time": "08:30"
+      },
+      "Woodhouse Moor parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Woodhouse Moor parkrun",
+        "shortname": "woodhousemoor",
+        "time": "09:00"
+      },
+      "Woodley parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Woodley parkrun",
+        "shortname": "woodley",
+        "time": "10:30"
+      },
+      "Yeovil Montacute parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "Yeovil Montacute parkrun",
+        "shortname": "yeovilmontacute",
+        "time": "10:30"
+      },
+      "York parkrun": {
+        "country_code": "uk",
+        "country_domain": "www.parkrun.org.uk",
+        "longname": "York parkrun",
+        "shortname": "york",
+        "time": "09:00"
+      }
+    },
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/us.json
+++ b/data/parkrun-special-events/2019-20/parsed/us.json
@@ -1,0 +1,196 @@
+{
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {
+      "Clermont Waterfront parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Clermont Waterfront parkrun",
+        "shortname": "clermontwaterfront",
+        "time": "09:00"
+      },
+      "College Park parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "College Park parkrun",
+        "shortname": "collegepark",
+        "time": "10:30"
+      },
+      "Durham NC parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Durham NC parkrun",
+        "shortname": "durhamnc",
+        "time": "09:30"
+      },
+      "Fletcher's Cove parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Fletcher's Cove parkrun",
+        "shortname": "fletcherscove",
+        "time": "10:30"
+      },
+      "Himmel parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Himmel parkrun",
+        "shortname": "himmel",
+        "time": "09:00"
+      },
+      "Jamaica Pond parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Jamaica Pond parkrun",
+        "shortname": "jamaicapond",
+        "time": "10:00"
+      },
+      "Kensington parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Kensington parkrun",
+        "shortname": "kensington",
+        "time": "08:30"
+      },
+      "Lillie parkrun, Ann Arbor": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Lillie parkrun, Ann Arbor",
+        "shortname": "lillie",
+        "time": "10:30"
+      },
+      "Livonia parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Livonia parkrun",
+        "shortname": "livonia",
+        "time": "08:30"
+      },
+      "Oak Grove parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Oak Grove parkrun",
+        "shortname": "oakgrove",
+        "time": "10:00"
+      },
+      "Perrigo parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Perrigo parkrun",
+        "shortname": "perrigo",
+        "time": "08:30"
+      },
+      "Rec Plex North parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Rec Plex North parkrun",
+        "shortname": "recplexnorth",
+        "time": "07:30"
+      },
+      "Renton parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Renton parkrun",
+        "shortname": "renton",
+        "time": "10:30"
+      },
+      "South Boulder Creek parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "South Boulder Creek parkrun",
+        "shortname": "southbouldercreek",
+        "time": "10:30"
+      }
+    },
+    "index": 3
+  },
+  "Thanksgiving": {
+    "date": "2018-11-28",
+    "events": {
+      "Clermont Waterfront parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Clermont Waterfront parkrun",
+        "shortname": "clermontwaterfront",
+        "time": "07:30"
+      },
+      "College Park parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "College Park parkrun",
+        "shortname": "collegepark",
+        "time": "09:00"
+      },
+      "Delaware and Raritan Canal parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Delaware and Raritan Canal parkrun",
+        "shortname": "delawareandraritancanal",
+        "time": "09:00"
+      },
+      "Eagan parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Eagan parkrun",
+        "shortname": "eagan",
+        "time": "09:00"
+      },
+      "Jamaica Pond parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Jamaica Pond parkrun",
+        "shortname": "jamaicapond",
+        "time": "09:00"
+      },
+      "Kensington parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Kensington parkrun",
+        "shortname": "kensington",
+        "time": "09:00"
+      },
+      "Lillie parkrun, Ann Arbor": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Lillie parkrun, Ann Arbor",
+        "shortname": "lillie",
+        "time": "09:00"
+      },
+      "Livonia parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Livonia parkrun",
+        "shortname": "livonia",
+        "time": "09:00"
+      },
+      "Oak Grove parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Oak Grove parkrun",
+        "shortname": "oakgrove",
+        "time": "09:00"
+      },
+      "Perrigo parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Perrigo parkrun",
+        "shortname": "perrigo",
+        "time": "09:00"
+      },
+      "Rec Plex North parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Rec Plex North parkrun",
+        "shortname": "recplexnorth",
+        "time": "07:30"
+      },
+      "Terry Hershey parkrun": {
+        "country_code": "us",
+        "country_domain": "www.parkrun.us",
+        "longname": "Terry Hershey parkrun",
+        "shortname": "terryhershey",
+        "time": "09:00"
+      }
+    },
+    "index": 2
+  }
+}

--- a/data/parkrun-special-events/2019-20/parsed/za.json
+++ b/data/parkrun-special-events/2019-20/parsed/za.json
@@ -1,0 +1,105 @@
+{
+  "Christmas Day": {
+    "date": "2019-12-25",
+    "events": {
+      "Bronberrik parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Bronberrik parkrun",
+        "shortname": "bronberrik",
+        "time": "08:00"
+      },
+      "Delta parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Delta parkrun",
+        "shortname": "delta",
+        "time": "08:00"
+      },
+      "Kimberley parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Kimberley parkrun",
+        "shortname": "kimberley",
+        "time": "07:00"
+      },
+      "Koster parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Koster parkrun",
+        "shortname": "koster",
+        "time": "07:00"
+      },
+      "Mogol parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Mogol parkrun",
+        "shortname": "mogol",
+        "time": "07:00"
+      }
+    },
+    "index": 2
+  },
+  "New Year's Day": {
+    "date": "2020-01-01",
+    "events": {
+      "Bellville parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Bellville parkrun",
+        "shortname": "bellville",
+        "time": "08:00"
+      },
+      "Bryanston parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Bryanston parkrun",
+        "shortname": "bryanston",
+        "time": "07:30"
+      },
+      "Delta parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Delta parkrun",
+        "shortname": "delta",
+        "time": "09:30"
+      },
+      "Harkerville parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Harkerville parkrun",
+        "shortname": "harkerville",
+        "time": "09:00"
+      },
+      "Kimberley parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Kimberley parkrun",
+        "shortname": "kimberley",
+        "time": "07:00"
+      },
+      "Koster parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Koster parkrun",
+        "shortname": "koster",
+        "time": "08:30"
+      },
+      "Mogol parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Mogol parkrun",
+        "shortname": "mogol",
+        "time": "07:00"
+      },
+      "Sterkfontein parkrun": {
+        "country_code": "za",
+        "country_domain": "www.parkrun.co.za",
+        "longname": "Sterkfontein parkrun",
+        "shortname": "sterkfontein",
+        "time": "07:30"
+      }
+    },
+    "index": 3
+  }
+}

--- a/data/parkrun-special-events/fetch.sh
+++ b/data/parkrun-special-events/fetch.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-YEAR=${1:-"2018-19"}
+YEAR=${1:-"2019-20"}
 
 echo "Fetching files for ${YEAR}"
+
+# Ensure we have a directory for the raw data and parsed data
+mkdir -p ${YEAR}/raw/
+mkdir -p ${YEAR}/parsed/
 
 # All the special events pages, as listed at
 # https://www.parkrun.com/christmas-and-new-year/

--- a/scripts/parkrun-special-events/parkrun-special-events.py
+++ b/scripts/parkrun-special-events/parkrun-special-events.py
@@ -86,37 +86,44 @@ def parse_special_events_table(table, country_code, special_events_data, year):
 special_events_data = {
     'Thanksgiving': {
         'dates': {
-            '2018-19': '2018-11-22'
+            '2018-19': '2018-11-22',
+            '2019-20': '2018-11-28'
         }
     },
     'Christmas Eve': {
         'dates': {
-            '2018-19': '2018-12-24'
+            '2018-19': '2018-12-24',
+            '2019-20': '2019-12-24'
         }
     },
     'Christmas Day': {
         'dates': {
-            '2018-19': '2018-12-25'
+            '2018-19': '2018-12-25',
+            '2019-20': '2019-12-25'
         }
     },
     'Boxing Day': {
         'dates': {
-            '2018-19': '2018-12-26'
+            '2018-19': '2018-12-26',
+            '2019-20': '2019-12-26'
         }
     },
     'New Year\'s Day': {
         'dates': {
-            '2018-19': '2019-01-01'
+            '2018-19': '2019-01-01',
+            '2019-20': '2020-01-01'
         }
     },
     'Orthodox Christmas': {
         'dates': {
-            '2018-19': '2019-01-07'
+            '2018-19': '2019-01-07',
+            '2019-20': '2020-01-07'
         }
     },
     'Chinese New Year': {
         'dates': {
-            '2018-19': '2019-02-05'
+            '2018-19': '2019-02-05',
+            '2019-20': '2020-01-20'
         }
     },
     'translations': {
@@ -162,7 +169,7 @@ special_events_data = {
 }
 
 # Make this a parameter at some point, but for now, it's hardcoded
-this_year = '2018-19'
+this_year = '2019-20'
 
 input_files = dict()
 # Load the entire page, in all its messy glory


### PR DESCRIPTION
I was considering extending the plugin to include 'nearest double not done' (or similar) - it would need this switch to 19/20 data.